### PR TITLE
Indentation correction for Aave lending providers

### DIFF
--- a/packages/protocol/test/arbitrum/aaveV3/Provider.t.sol
+++ b/packages/protocol/test/arbitrum/aaveV3/Provider.t.sol
@@ -41,7 +41,6 @@ contract ProviderTest is DSTestPlus, CoreRoles {
     weth = IWETH9(0x82aF49447D8a07e3bd95BD0d56f35241523fBab1);
     usdc = IERC20(0xFF970A61A04b1cA14834A43f5dE4533eBDDB5CC8);
 
-
     vm.label(address(alice), "alice");
     vm.label(address(bob), "bob");
     vm.label(address(weth), "weth");

--- a/packages/protocol/test/optimism/aaveV3/Provider.t.sol
+++ b/packages/protocol/test/optimism/aaveV3/Provider.t.sol
@@ -70,7 +70,7 @@ contract ProviderTest is DSTestPlus, CoreRoles {
     aaveV3 = new AaveV3Optimism();
     ILendingProvider[] memory providers = new ILendingProvider[](1);
     providers[0] = aaveV3;
-   
+
     _utils_setupVaultProvider(vault, providers);
   }
 

--- a/packages/protocol/test/polygon/aaveV2/Provider.t.sol
+++ b/packages/protocol/test/polygon/aaveV2/Provider.t.sol
@@ -41,7 +41,6 @@ contract ProviderTest is DSTestPlus, CoreRoles {
     weth = IWETH9(0x7ceB23fD6bC0adD59E62ac25578270cFf1b9f619);
     usdc = IERC20(0x2791Bca1f2de4661ED88A30C99A7a9449Aa84174);
 
-
     vm.label(address(alice), "alice");
     vm.label(address(bob), "bob");
     vm.label(address(weth), "weth");

--- a/packages/protocol/test/polygon/aaveV3/Provider.t.sol
+++ b/packages/protocol/test/polygon/aaveV3/Provider.t.sol
@@ -152,7 +152,6 @@ contract ProviderTest is DSTestPlus, CoreRoles {
     _utils_doWithdrawRoutine(alice, maxAmount);
   }
 
-
   function test_getBalances() public {
     deal(address(weth), alice, DEPOSIT_AMOUNT);
     _utils_doDepositRoutine(alice, DEPOSIT_AMOUNT);


### PR DESCRIPTION
After fixing the foundryup issue, just corrected the files that were't correctly formatted.