### PR TITLE
Radiant as lending provider

### DIFF
--- a/packages/protocol/src/providers/arbitrum/RadiantArbitrum.sol
+++ b/packages/protocol/src/providers/arbitrum/RadiantArbitrum.sol
@@ -22,7 +22,16 @@ contract RadiantArbitrum is ILendingProvider {
   }
 
   /// inheritdoc ILendingProvider
-  function approvedOperator(address, address) external pure override returns (address operator) {
+  function approvedOperator(
+    address,
+    address,
+    address
+  )
+    external
+    pure
+    override
+    returns (address operator)
+  {
     operator = address(_getPool());
   }
 

--- a/packages/protocol/src/providers/arbitrum/RadiantArbitrum.sol
+++ b/packages/protocol/src/providers/arbitrum/RadiantArbitrum.sol
@@ -1,0 +1,101 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
+pragma solidity 0.8.15;
+
+import {IERC20} from "openzeppelin-contracts/contracts/token/ERC20/IERC20.sol";
+import {IVault} from "../../interfaces/IVault.sol";
+import {ILendingProvider} from "../../interfaces/ILendingProvider.sol";
+import {IV2Pool} from "../../interfaces/aaveV2/IV2Pool.sol";
+
+/**
+ * @title Radiant Lending Provider.
+ * @author fujidao Labs
+ * @notice This contract allows interaction with Radiant.
+ */
+contract RadiantArbitrum is ILendingProvider {
+  function _getPool() internal pure returns (IV2Pool) {
+    return IV2Pool(0x2032b9A8e9F7e76768CA9271003d3e43E1616B1F);
+  }
+
+  /// inheritdoc ILendingProvider
+  function providerName() public pure override returns (string memory) {
+    return "Radiant_Arbitrum";
+  }
+
+  /// inheritdoc ILendingProvider
+  function approvedOperator(address, address) external pure override returns (address operator) {
+    operator = address(_getPool());
+  }
+
+  /// inheritdoc ILendingProvider
+  function deposit(uint256 amount, IVault vault) external override returns (bool success) {
+    IV2Pool aave = _getPool();
+    aave.deposit(vault.asset(), amount, address(vault), 0);
+    // aave.setUserUseReserveAsCollateral(asset, true);
+    success = true;
+  }
+
+  /// inheritdoc ILendingProvider
+  function borrow(uint256 amount, IVault vault) external override returns (bool success) {
+    IV2Pool aave = _getPool();
+    aave.borrow(vault.debtAsset(), amount, 2, 0, address(vault));
+    success = true;
+  }
+
+  /// inheritdoc ILendingProvider
+  function withdraw(uint256 amount, IVault vault) external override returns (bool success) {
+    IV2Pool aave = _getPool();
+    aave.withdraw(vault.asset(), amount, address(vault));
+    success = true;
+  }
+
+  /// inheritdoc ILendingProvider
+  function payback(uint256 amount, IVault vault) external override returns (bool success) {
+    IV2Pool aave = _getPool();
+    aave.repay(vault.debtAsset(), amount, 2, address(vault));
+    success = true;
+  }
+
+  /// inheritdoc ILendingProvider
+  function getDepositRateFor(IVault vault) external view override returns (uint256 rate) {
+    IV2Pool aaveData = _getPool();
+    IV2Pool.ReserveData memory rdata = aaveData.getReserveData(vault.asset());
+    rate = rdata.currentLiquidityRate;
+  }
+
+  /// inheritdoc ILendingProvider
+  function getBorrowRateFor(IVault vault) external view override returns (uint256 rate) {
+    IV2Pool aaveData = _getPool();
+    IV2Pool.ReserveData memory rdata = aaveData.getReserveData(vault.debtAsset());
+    rate = rdata.currentVariableBorrowRate;
+  }
+
+  /// inheritdoc ILendingProvider
+  function getDepositBalance(
+    address user,
+    IVault vault
+  )
+    external
+    view
+    override
+    returns (uint256 balance)
+  {
+    IV2Pool aaveData = _getPool();
+    IV2Pool.ReserveData memory rdata = aaveData.getReserveData(vault.asset());
+    balance = IERC20(rdata.aTokenAddress).balanceOf(user);
+  }
+
+  /// inheritdoc ILendingProvider
+  function getBorrowBalance(
+    address user,
+    IVault vault
+  )
+    external
+    view
+    override
+    returns (uint256 balance)
+  {
+    IV2Pool aaveData = _getPool();
+    IV2Pool.ReserveData memory rdata = aaveData.getReserveData(vault.debtAsset());
+    balance = IERC20(rdata.variableDebtTokenAddress).balanceOf(user);
+  }
+}

--- a/packages/protocol/test/forking/arbitrum/RadiantArbitrum.t.sol
+++ b/packages/protocol/test/forking/arbitrum/RadiantArbitrum.t.sol
@@ -1,0 +1,74 @@
+// SPDX-License-Identifier: UNLICENSED
+pragma solidity 0.8.15;
+
+import "forge-std/console.sol";
+import {Routines} from "../../utils/Routines.sol";
+import {ForkingSetup} from "../ForkingSetup.sol";
+import {RadiantArbitrum} from "../../../src/providers/arbitrum/RadiantArbitrum.sol";
+import {ILendingProvider} from "../../../src/interfaces/ILendingProvider.sol";
+import {BorrowingVault} from "../../../src/vaults/borrowing/BorrowingVault.sol";
+import {IERC20} from "openzeppelin-contracts/contracts/token/ERC20/IERC20.sol";
+
+contract RadiantArbitrumForkingTest is Routines, ForkingSetup {
+  ILendingProvider public radiant;
+
+  uint256 public constant DEPOSIT_AMOUNT = 0.5 ether;
+  uint256 public constant BORROW_AMOUNT = 200 * 1e6;
+
+  function setUp() public {
+    deploy(ARBITRUM_DOMAIN);
+
+    radiant = new RadiantArbitrum();
+    ILendingProvider[] memory providers = new ILendingProvider[](1);
+    providers[0] = radiant;
+
+    _setVaultProviders(vault, providers);
+    vault.setActiveProvider(radiant);
+  }
+
+  function test_depositAndBorrow() public {
+    do_deposit(DEPOSIT_AMOUNT, vault, ALICE);
+    do_borrow(BORROW_AMOUNT, vault, ALICE);
+  }
+
+  function test_paybackAndWithdraw() public {
+    deal(address(vault.asset()), ALICE, DEPOSIT_AMOUNT);
+
+    do_depositAndBorrow(DEPOSIT_AMOUNT, BORROW_AMOUNT, vault, ALICE);
+
+    vm.warp(block.timestamp + 13 seconds);
+    vm.roll(block.number + 1);
+
+    uint256 aliceDebt = vault.balanceOfDebt(ALICE);
+    do_payback(aliceDebt, vault, ALICE);
+
+    assertEq(vault.balanceOfDebt(ALICE), 0);
+
+    uint256 maxAmount = vault.maxWithdraw(ALICE);
+    do_withdraw(maxAmount, vault, ALICE);
+
+    assertGe(IERC20(vault.asset()).balanceOf(ALICE), DEPOSIT_AMOUNT);
+  }
+
+  function test_getBalances() public {
+    do_depositAndBorrow(DEPOSIT_AMOUNT, BORROW_AMOUNT, vault, ALICE);
+
+    uint256 depositBalance = vault.totalAssets();
+    uint256 borrowBalance = vault.totalDebt();
+    assertGe(depositBalance, DEPOSIT_AMOUNT);
+    assertGe(borrowBalance, BORROW_AMOUNT);
+  }
+
+  function test_getInterestRates() public {
+    uint256 depositRate = radiant.getDepositRateFor(vault);
+    assertGt(depositRate, 0); // Should be greater than zero.
+
+    uint256 borrowRate = radiant.getBorrowRateFor(vault);
+    assertGt(borrowRate, 0); // Should be greater than zero.
+  }
+
+  function test_twoDeposits() public {
+    do_deposit(DEPOSIT_AMOUNT, vault, ALICE);
+    do_deposit(DEPOSIT_AMOUNT, vault, BOB);
+  }
+}

--- a/packages/protocol/test/forking/arbitrum/RadiantArbitrum.t.sol
+++ b/packages/protocol/test/forking/arbitrum/RadiantArbitrum.t.sol
@@ -6,7 +6,6 @@ import {Routines} from "../../utils/Routines.sol";
 import {ForkingSetup} from "../ForkingSetup.sol";
 import {RadiantArbitrum} from "../../../src/providers/arbitrum/RadiantArbitrum.sol";
 import {ILendingProvider} from "../../../src/interfaces/ILendingProvider.sol";
-import {BorrowingVault} from "../../../src/vaults/borrowing/BorrowingVault.sol";
 import {IERC20} from "openzeppelin-contracts/contracts/token/ERC20/IERC20.sol";
 
 contract RadiantArbitrumForkingTest is Routines, ForkingSetup {
@@ -16,14 +15,13 @@ contract RadiantArbitrumForkingTest is Routines, ForkingSetup {
   uint256 public constant BORROW_AMOUNT = 200 * 1e6;
 
   function setUp() public {
-    deploy(ARBITRUM_DOMAIN);
+    setUpFork(ARBITRUM_DOMAIN);
 
     radiant = new RadiantArbitrum();
     ILendingProvider[] memory providers = new ILendingProvider[](1);
     providers[0] = radiant;
 
-    _setVaultProviders(vault, providers);
-    vault.setActiveProvider(radiant);
+    deploy(providers);
   }
 
   function test_depositAndBorrow() public {


### PR DESCRIPTION
I was starting to integrate radiant when I realized it looked exactly like AaveV2 (same functions and same "structure").
I used the IV2Pool interface as it had the same functions we needed judging by their contracts and used the same code as the aavev2 provider integration changing the address of the pool we interact with (radiant's pool).