### PR TITLE
Balancer flashloan provider

### DIFF
--- a/packages/protocol/src/flashloans/FlasherBalancer.sol
+++ b/packages/protocol/src/flashloans/FlasherBalancer.sol
@@ -1,0 +1,69 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
+pragma solidity 0.8.15;
+
+/**
+ * @title FlasherBalancer
+ * @author Fujidao Labs
+ * @notice Handles logic of Balancer as a flashloan provider.
+ */
+
+import {BaseFlasher} from "../abstracts/BaseFlasher.sol";
+import {IBalancerVault} from "../interfaces/balancer/IBalancerVault.sol";
+import {IFlashLoanRecipient} from "../interfaces/balancer/IFlashLoanRecipient.sol";
+import {IERC20} from "openzeppelin-contracts/contracts/token/ERC20/IERC20.sol";
+import {SafeERC20} from "openzeppelin-contracts/contracts/token/ERC20/utils/SafeERC20.sol";
+
+contract FlasherBalancer is BaseFlasher, IFlashLoanRecipient {
+  constructor(address balancerVault) BaseFlasher("FlasherBalancer", balancerVault) {}
+
+  /// @inheritdoc BaseFlasher
+  function initiateFlashloan(
+    address asset,
+    uint256 amount,
+    address requestor,
+    bytes memory requestorCalldata
+  )
+    external
+    override
+  {
+    bytes memory data = abi.encode(asset, amount, requestor, requestorCalldata);
+    _checkAndSetEntryPoint(data);
+
+    IERC20[] memory tokens = new IERC20[](1);
+    tokens[0] = IERC20(asset);
+    uint256[] memory amounts = new uint256[](1);
+    amounts[0] = amount;
+
+    IBalancerVault(getFlashloanSourceAddr(asset)).flashLoan(this, tokens, amounts, data);
+  }
+
+  function computeFlashloanFee(address, uint256) external pure override returns (uint256 fee) {
+    fee = 0;
+  }
+
+  /**
+   * @dev Callback enforced by Balancer Flashloan
+   */
+  function receiveFlashLoan(
+    IERC20[] memory tokens,
+    uint256[] memory amounts,
+    uint256[] memory, /*feeAmounts*/
+    bytes calldata userData
+  )
+    external
+  {
+    (address asset, uint256 amount, address requestor, bytes memory requestorCalldata) =
+      _checkReentryPoint(userData);
+
+    if (
+      address(tokens[0]) != asset || amounts[0] != amount
+        || msg.sender != getFlashloanSourceAddr(asset)
+    ) {
+      revert BaseFlasher__notAuthorized();
+    }
+
+    _requestorExecution(address(tokens[0]), amounts[0], 0, requestor, requestorCalldata);
+
+    SafeERC20.safeTransfer(tokens[0], getFlashloanSourceAddr(asset), amounts[0]);
+  }
+}

--- a/packages/protocol/src/interfaces/balancer/IBalancerVault.sol
+++ b/packages/protocol/src/interfaces/balancer/IBalancerVault.sol
@@ -1,0 +1,39 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
+pragma solidity 0.8.15;
+
+import {IFlashLoanRecipient} from "./IFlashLoanRecipient.sol";
+import {IERC20} from "openzeppelin-contracts/contracts/token/ERC20/IERC20.sol";
+
+/**
+ * @dev Partial interface for the vault, only for flash loans
+ */
+interface IBalancerVault {
+  // Flash Loans
+
+  /**
+   * @dev Performs a 'flash loan', sending tokens to `recipient`, executing the `receiveFlashLoan` hook on it,
+   * and then reverting unless the tokens plus a proportional protocol fee have been returned.
+   *
+   * The `tokens` and `amounts` arrays must have the same length, and each entry in these indicates the loan amount
+   * for each token contract. `tokens` must be sorted in ascending order.
+   *
+   * The 'userData' field is ignored by the Vault, and forwarded as-is to `recipient` as part of the
+   * `receiveFlashLoan` call.
+   *
+   * Emits `FlashLoan` events.
+   */
+  function flashLoan(
+    IFlashLoanRecipient recipient,
+    IERC20[] memory tokens,
+    uint256[] memory amounts,
+    bytes memory userData
+  )
+    external;
+
+  /**
+   * @dev Emitted for each individual flash loan performed by `flashLoan`.
+   */
+  event FlashLoan(
+    IFlashLoanRecipient indexed recipient, IERC20 indexed token, uint256 amount, uint256 feeAmount
+  );
+}

--- a/packages/protocol/src/interfaces/balancer/IBalancerVault.sol
+++ b/packages/protocol/src/interfaces/balancer/IBalancerVault.sol
@@ -3,6 +3,7 @@ pragma solidity 0.8.15;
 
 import {IFlashLoanRecipient} from "./IFlashLoanRecipient.sol";
 import {IERC20} from "openzeppelin-contracts/contracts/token/ERC20/IERC20.sol";
+import {IProtocolFeesCollector} from "./IProtocolFeesCollector.sol";
 
 /**
  * @dev Partial interface for the vault, only for flash loans
@@ -36,4 +37,24 @@ interface IBalancerVault {
   event FlashLoan(
     IFlashLoanRecipient indexed recipient, IERC20 indexed token, uint256 amount, uint256 feeAmount
   );
+
+  // Protocol Fees
+  //
+  // Some operations cause the Vault to collect tokens in the form of protocol fees, which can then be withdrawn by
+  // permissioned accounts.
+  //
+  // There are two kinds of protocol fees:
+  //
+  //  - flash loan fees: charged on all flash loans, as a percentage of the amounts lent.
+  //
+  //  - swap fees: a percentage of the fees charged by Pools when performing swaps. For a number of reasons, including
+  // swap gas costs and interface simplicity, protocol swap fees are not charged on each individual swap. Rather,
+  // Pools are expected to keep track of how much they have charged in swap fees, and pay any outstanding debts to the
+  // Vault when they are joined or exited. This prevents users from joining a Pool with unpaid debt, as well as
+  // exiting a Pool in debt without first paying their share.
+
+  /**
+   * @dev Returns the current protocol fee module.
+   */
+  function getProtocolFeesCollector() external view returns (IProtocolFeesCollector);
 }

--- a/packages/protocol/src/interfaces/balancer/IFlashLoanRecipient.sol
+++ b/packages/protocol/src/interfaces/balancer/IFlashLoanRecipient.sol
@@ -1,0 +1,38 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+
+// You should have received a copy of the GNU General Public License
+// along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+pragma solidity 0.8.15;
+
+// Inspired by Aave Protocol's IFlashLoanReceiver.
+
+import {IERC20} from "openzeppelin-contracts/contracts/token/ERC20/IERC20.sol";
+
+interface IFlashLoanRecipient {
+  /**
+   * @dev When `flashLoan` is called on the Vault, it invokes the `receiveFlashLoan` hook on the recipient.
+   *
+   * At the time of the call, the Vault will have transferred `amounts` for `tokens` to the recipient. Before this
+   * call returns, the recipient must have transferred `amounts` plus `feeAmounts` for each token back to the
+   * Vault, or else the entire flash loan will revert.
+   *
+   * `userData` is the same value passed in the `IVault.flashLoan` call.
+   */
+  function receiveFlashLoan(
+    IERC20[] memory tokens,
+    uint256[] memory amounts,
+    uint256[] memory feeAmounts,
+    bytes memory userData
+  )
+    external;
+}

--- a/packages/protocol/src/interfaces/balancer/IProtocolFeesCollector.sol
+++ b/packages/protocol/src/interfaces/balancer/IProtocolFeesCollector.sol
@@ -1,0 +1,23 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+
+// You should have received a copy of the GNU General Public License
+// along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+pragma solidity 0.8.15;
+
+import {IERC20} from "openzeppelin-contracts/contracts/token/ERC20/IERC20.sol";
+
+interface IProtocolFeesCollector {
+  event FlashLoanFeePercentageChanged(uint256 newFlashLoanFeePercentage);
+
+  function getFlashLoanFeePercentage() external view returns (uint256);
+}

--- a/packages/protocol/test/forking/arbitrum/FlasherBalancerArbitrum.t.sol
+++ b/packages/protocol/test/forking/arbitrum/FlasherBalancerArbitrum.t.sol
@@ -1,0 +1,104 @@
+// SPDX-License-Identifier: UNLICENSED
+pragma solidity 0.8.15;
+
+import "forge-std/console.sol";
+import {Routines} from "../../utils/Routines.sol";
+import {ForkingSetup} from "../ForkingSetup.sol";
+import {ILendingProvider} from "../../../src/interfaces/ILendingProvider.sol";
+import {IVault} from "../../../src/interfaces/IVault.sol";
+import {FlasherBalancer} from "../../../src/flashloans/FlasherBalancer.sol";
+import {IFlasher} from "../../../src/interfaces/IFlasher.sol";
+import {RebalancerManager} from "../../../src/RebalancerManager.sol";
+import {IERC20} from "openzeppelin-contracts/contracts/token/ERC20/IERC20.sol";
+import {IBalancerVault} from "../../../src/interfaces/balancer/IBalancerVault.sol";
+import {IFlashLoanRecipient} from "../../../src/interfaces/balancer/IFlashLoanRecipient.sol";
+import {WePiggyArbitrum} from "../../../src/providers/arbitrum/WePiggyArbitrum.sol";
+import {DForceArbitrum} from "../../../src/providers/arbitrum/DForceArbitrum.sol";
+
+contract FlasherBalancerArbitrumForkingTest is Routines, ForkingSetup, IFlashLoanRecipient {
+  ILendingProvider public dForce;
+  ILendingProvider public wePiggy;
+
+  IFlasher public flasher;
+
+  RebalancerManager public rebalancer;
+
+  uint256 public constant DEPOSIT_AMOUNT = 1000e18;
+  uint256 public constant BORROW_AMOUNT = 100e6;
+
+  function setUp() public {
+    setUpFork(ARBITRUM_DOMAIN);
+
+    dForce = new DForceArbitrum();
+    wePiggy = new WePiggyArbitrum();
+
+    flasher = new FlasherBalancer(0xBA12222222228d8Ba445958a75a0704d566BF2C8);
+
+    ILendingProvider[] memory providers = new ILendingProvider[](2);
+    providers[0] = dForce;
+    providers[1] = wePiggy;
+
+    deploy(providers);
+
+    rebalancer = new RebalancerManager(address(chief));
+    _grantRoleChief(REBALANCER_ROLE, address(rebalancer));
+
+    bytes memory executionCall =
+      abi.encodeWithSelector(rebalancer.allowExecutor.selector, address(this), true);
+    _callWithTimelock(address(rebalancer), executionCall);
+
+    executionCall = abi.encodeWithSelector(chief.allowFlasher.selector, address(flasher), true);
+    _callWithTimelock(address(chief), executionCall);
+  }
+
+  function receiveFlashLoan(
+    IERC20[] memory, /*asset*/
+    uint256[] memory, /*amount*/
+    uint256[] memory, /*initiator*/
+    bytes calldata data
+  )
+    external
+  {
+    (IERC20[] memory assets, uint256[] memory amounts) = abi.decode(data, (IERC20[], uint256[]));
+
+    assertEq(assets[0].balanceOf(address(this)), amounts[0]);
+
+    IERC20(assets[0]).transfer(msg.sender, amounts[0]);
+  }
+
+  function test_flashloan() public {
+    IERC20[] memory tokens = new IERC20[](1);
+    tokens[0] = IERC20(debtAsset);
+    uint256[] memory amounts = new uint256[](1);
+    amounts[0] = BORROW_AMOUNT;
+
+    bytes memory data = abi.encode(tokens, amounts);
+
+    IBalancerVault(flasher.getFlashloanSourceAddr(debtAsset)).flashLoan(this, tokens, amounts, data);
+
+    assertEq(IERC20(debtAsset).balanceOf(address(this)), 0);
+  }
+
+  // test rebalance a full position to another provider
+  function test_rebalanceWithRebalancer() public {
+    do_depositAndBorrow(DEPOSIT_AMOUNT, BORROW_AMOUNT, vault, ALICE);
+
+    vm.warp(block.timestamp + 13 seconds);
+    vm.roll(block.number + 1);
+
+    uint256 debt = vault.totalDebt();
+    uint256 assets = vault.totalAssets();
+
+    rebalancer.rebalanceVault(vault, assets, debt, dForce, wePiggy, flasher, true);
+
+    //issue with rounding
+    assertApproxEqAbs(dForce.getDepositBalance(address(vault), vault), 0, DEPOSIT_AMOUNT / 1000);
+    assertApproxEqAbs(dForce.getBorrowBalance(address(vault), vault), 0, DEPOSIT_AMOUNT / 1000);
+
+    //issue with rounding
+    assertApproxEqAbs(
+      wePiggy.getDepositBalance(address(vault), vault), assets, DEPOSIT_AMOUNT / 1000
+    );
+    assertApproxEqAbs(wePiggy.getBorrowBalance(address(vault), vault), debt, BORROW_AMOUNT / 1000);
+  }
+}

--- a/packages/protocol/test/forking/arbitrum/FlasherBalancerArbitrum.t.sol
+++ b/packages/protocol/test/forking/arbitrum/FlasherBalancerArbitrum.t.sol
@@ -54,14 +54,14 @@ contract FlasherBalancerArbitrumForkingTest is Routines, ForkingSetup, IFlashLoa
   function receiveFlashLoan(
     IERC20[] memory, /*asset*/
     uint256[] memory, /*amount*/
-    uint256[] memory, /*initiator*/
+    uint256[] memory feeAmounts,
     bytes calldata data
   )
     external
   {
     (IERC20[] memory assets, uint256[] memory amounts) = abi.decode(data, (IERC20[], uint256[]));
 
-    assertEq(assets[0].balanceOf(address(this)), amounts[0]);
+    assertEq(assets[0].balanceOf(address(this)), amounts[0] + feeAmounts[0]);
 
     IERC20(assets[0]).transfer(msg.sender, amounts[0]);
   }
@@ -73,6 +73,9 @@ contract FlasherBalancerArbitrumForkingTest is Routines, ForkingSetup, IFlashLoa
     amounts[0] = BORROW_AMOUNT;
 
     bytes memory data = abi.encode(tokens, amounts);
+
+    //deal premium
+    deal(address(debtAsset), address(this), flasher.computeFlashloanFee(debtAsset, BORROW_AMOUNT));
 
     IBalancerVault(flasher.getFlashloanSourceAddr(debtAsset)).flashLoan(this, tokens, amounts, data);
 

--- a/packages/protocol/test/forking/gnosis/FlasherBalancerGnosis.t.sol
+++ b/packages/protocol/test/forking/gnosis/FlasherBalancerGnosis.t.sol
@@ -1,0 +1,112 @@
+// SPDX-License-Identifier: UNLICENSED
+pragma solidity 0.8.15;
+
+import "forge-std/console.sol";
+import {Routines} from "../../utils/Routines.sol";
+import {ForkingSetup} from "../ForkingSetup.sol";
+import {ILendingProvider} from "../../../src/interfaces/ILendingProvider.sol";
+import {IVault} from "../../../src/interfaces/IVault.sol";
+import {FlasherBalancer} from "../../../src/flashloans/FlasherBalancer.sol";
+import {IFlasher} from "../../../src/interfaces/IFlasher.sol";
+import {RebalancerManager} from "../../../src/RebalancerManager.sol";
+import {IERC20} from "openzeppelin-contracts/contracts/token/ERC20/IERC20.sol";
+import {IBalancerVault} from "../../../src/interfaces/balancer/IBalancerVault.sol";
+import {IFlashLoanRecipient} from "../../../src/interfaces/balancer/IFlashLoanRecipient.sol";
+import {AgaveGnosis} from "../../../src/providers/gnosis/AgaveGnosis.sol";
+import {HundredGnosis} from "../../../src/providers/gnosis/HundredGnosis.sol";
+
+contract FlasherBalancerGnosisForkingTest is Routines, ForkingSetup, IFlashLoanRecipient {
+  ILendingProvider public agave;
+  ILendingProvider public hundred;
+
+  IFlasher public flasher;
+
+  RebalancerManager public rebalancer;
+
+  uint256 public constant DEPOSIT_AMOUNT = 1000e18;
+  uint256 public constant BORROW_AMOUNT = 100e6;
+
+  function setUp() public {
+    setUpFork(GNOSIS_DOMAIN);
+
+    agave = new AgaveGnosis();
+    hundred = new HundredGnosis();
+
+    flasher = new FlasherBalancer(0xBA12222222228d8Ba445958a75a0704d566BF2C8);
+
+    ILendingProvider[] memory providers = new ILendingProvider[](2);
+    providers[0] = agave;
+    providers[1] = hundred;
+
+    deployVault(
+      registry[GNOSIS_DOMAIN].weth,
+      registry[GNOSIS_DOMAIN].dai,
+      796341757142697,
+      100000000,
+      "WETH",
+      "DAI",
+      providers
+    );
+
+    rebalancer = new RebalancerManager(address(chief));
+    _grantRoleChief(REBALANCER_ROLE, address(rebalancer));
+
+    bytes memory executionCall =
+      abi.encodeWithSelector(rebalancer.allowExecutor.selector, address(this), true);
+    _callWithTimelock(address(rebalancer), executionCall);
+
+    executionCall = abi.encodeWithSelector(chief.allowFlasher.selector, address(flasher), true);
+    _callWithTimelock(address(chief), executionCall);
+  }
+
+  function receiveFlashLoan(
+    IERC20[] memory, /*asset*/
+    uint256[] memory, /*amount*/
+    uint256[] memory, /*initiator*/
+    bytes calldata data
+  )
+    external
+  {
+    (IERC20[] memory assets, uint256[] memory amounts) = abi.decode(data, (IERC20[], uint256[]));
+
+    assertEq(assets[0].balanceOf(address(this)), amounts[0]);
+
+    IERC20(assets[0]).transfer(msg.sender, amounts[0]);
+  }
+
+  function test_flashloan() public {
+    IERC20[] memory tokens = new IERC20[](1);
+    tokens[0] = IERC20(debtAsset);
+    uint256[] memory amounts = new uint256[](1);
+    amounts[0] = BORROW_AMOUNT;
+
+    bytes memory data = abi.encode(tokens, amounts);
+
+    IBalancerVault(flasher.getFlashloanSourceAddr(debtAsset)).flashLoan(this, tokens, amounts, data);
+
+    assertEq(IERC20(debtAsset).balanceOf(address(this)), 0);
+  }
+
+  // test rebalance a full position to another provider
+  function test_rebalanceWithRebalancer() public {
+    do_depositAndBorrow(DEPOSIT_AMOUNT, BORROW_AMOUNT, vault, ALICE);
+
+    vm.warp(block.timestamp + 13 seconds);
+    vm.roll(block.number + 1);
+
+    uint256 debt = vault.totalDebt();
+    uint256 assets = vault.totalAssets();
+
+    rebalancer.rebalanceVault(vault, assets, debt, agave, hundred, flasher, true);
+
+    //issue with rounding
+    assertApproxEqAbs(agave.getDepositBalance(address(vault), vault), 0, DEPOSIT_AMOUNT / 1000);
+    assertApproxEqAbs(agave.getBorrowBalance(address(vault), vault), 0, DEPOSIT_AMOUNT / 1000);
+
+    //issue with rounding
+    assertApproxEqAbs(
+      hundred.getDepositBalance(address(vault), vault), assets, DEPOSIT_AMOUNT / 1000
+    );
+    assertApproxEqAbs(hundred.getBorrowBalance(address(vault), vault), debt, BORROW_AMOUNT / 1000);
+  }
+}

--- a/packages/protocol/test/forking/gnosis/FlasherBalancerGnosis.t.sol
+++ b/packages/protocol/test/forking/gnosis/FlasherBalancerGnosis.t.sol
@@ -62,14 +62,14 @@ contract FlasherBalancerGnosisForkingTest is Routines, ForkingSetup, IFlashLoanR
   function receiveFlashLoan(
     IERC20[] memory, /*asset*/
     uint256[] memory, /*amount*/
-    uint256[] memory, /*initiator*/
+    uint256[] memory feeAmounts,
     bytes calldata data
   )
     external
   {
     (IERC20[] memory assets, uint256[] memory amounts) = abi.decode(data, (IERC20[], uint256[]));
 
-    assertEq(assets[0].balanceOf(address(this)), amounts[0]);
+    assertEq(assets[0].balanceOf(address(this)), amounts[0] + feeAmounts[0]);
 
     IERC20(assets[0]).transfer(msg.sender, amounts[0]);
   }
@@ -81,6 +81,9 @@ contract FlasherBalancerGnosisForkingTest is Routines, ForkingSetup, IFlashLoanR
     amounts[0] = BORROW_AMOUNT;
 
     bytes memory data = abi.encode(tokens, amounts);
+
+    //deal premium
+    deal(address(debtAsset), address(this), flasher.computeFlashloanFee(debtAsset, BORROW_AMOUNT));
 
     IBalancerVault(flasher.getFlashloanSourceAddr(debtAsset)).flashLoan(this, tokens, amounts, data);
 

--- a/packages/protocol/test/forking/mainnet/FlasherBalancer.t.sol
+++ b/packages/protocol/test/forking/mainnet/FlasherBalancer.t.sol
@@ -54,14 +54,14 @@ contract FlasherBalancerForkingTest is Routines, ForkingSetup, IFlashLoanRecipie
   function receiveFlashLoan(
     IERC20[] memory, /*asset*/
     uint256[] memory, /*amount*/
-    uint256[] memory, /*initiator*/
+    uint256[] memory feeAmounts,
     bytes calldata data
   )
     external
   {
     (IERC20[] memory assets, uint256[] memory amounts) = abi.decode(data, (IERC20[], uint256[]));
 
-    assertEq(assets[0].balanceOf(address(this)), amounts[0]);
+    assertEq(assets[0].balanceOf(address(this)), amounts[0] + feeAmounts[0]);
 
     IERC20(assets[0]).transfer(msg.sender, amounts[0]);
   }
@@ -73,6 +73,9 @@ contract FlasherBalancerForkingTest is Routines, ForkingSetup, IFlashLoanRecipie
     amounts[0] = BORROW_AMOUNT;
 
     bytes memory data = abi.encode(tokens, amounts);
+
+    //deal premium
+    deal(address(debtAsset), address(this), flasher.computeFlashloanFee(debtAsset, BORROW_AMOUNT));
 
     IBalancerVault(flasher.getFlashloanSourceAddr(debtAsset)).flashLoan(this, tokens, amounts, data);
 

--- a/packages/protocol/test/forking/mainnet/FlasherBalancer.t.sol
+++ b/packages/protocol/test/forking/mainnet/FlasherBalancer.t.sol
@@ -1,0 +1,106 @@
+// SPDX-License-Identifier: UNLICENSED
+pragma solidity 0.8.15;
+
+import "forge-std/console.sol";
+import {Routines} from "../../utils/Routines.sol";
+import {ForkingSetup} from "../ForkingSetup.sol";
+import {ILendingProvider} from "../../../src/interfaces/ILendingProvider.sol";
+import {IVault} from "../../../src/interfaces/IVault.sol";
+import {FlasherBalancer} from "../../../src/flashloans/FlasherBalancer.sol";
+import {IFlasher} from "../../../src/interfaces/IFlasher.sol";
+import {RebalancerManager} from "../../../src/RebalancerManager.sol";
+import {IERC20} from "openzeppelin-contracts/contracts/token/ERC20/IERC20.sol";
+import {IBalancerVault} from "../../../src/interfaces/balancer/IBalancerVault.sol";
+import {IFlashLoanRecipient} from "../../../src/interfaces/balancer/IFlashLoanRecipient.sol";
+import {AaveV2} from "../../../src/providers/mainnet/AaveV2.sol";
+import {CompoundV3} from "../../../src/providers/mainnet/CompoundV3.sol";
+
+contract FlasherBalancerForkingTest is Routines, ForkingSetup, IFlashLoanRecipient {
+  ILendingProvider public aaveV2;
+  ILendingProvider public compoundV3;
+
+  IFlasher public flasher;
+
+  RebalancerManager public rebalancer;
+
+  uint256 public constant DEPOSIT_AMOUNT = 1000e18;
+  uint256 public constant BORROW_AMOUNT = 100e6;
+
+  function setUp() public {
+    setUpFork(MAINNET_DOMAIN);
+
+    aaveV2 = new AaveV2();
+    compoundV3 = new CompoundV3();
+
+    flasher = new FlasherBalancer(0xBA12222222228d8Ba445958a75a0704d566BF2C8);
+
+    ILendingProvider[] memory providers = new ILendingProvider[](2);
+    providers[0] = aaveV2;
+    providers[1] = compoundV3;
+
+    deploy(providers);
+
+    rebalancer = new RebalancerManager(address(chief));
+    _grantRoleChief(REBALANCER_ROLE, address(rebalancer));
+
+    bytes memory executionCall =
+      abi.encodeWithSelector(rebalancer.allowExecutor.selector, address(this), true);
+    _callWithTimelock(address(rebalancer), executionCall);
+
+    executionCall = abi.encodeWithSelector(chief.allowFlasher.selector, address(flasher), true);
+    _callWithTimelock(address(chief), executionCall);
+  }
+
+  function receiveFlashLoan(
+    IERC20[] memory, /*asset*/
+    uint256[] memory, /*amount*/
+    uint256[] memory, /*initiator*/
+    bytes calldata data
+  )
+    external
+  {
+    (IERC20[] memory assets, uint256[] memory amounts) = abi.decode(data, (IERC20[], uint256[]));
+
+    assertEq(assets[0].balanceOf(address(this)), amounts[0]);
+
+    IERC20(assets[0]).transfer(msg.sender, amounts[0]);
+  }
+
+  function test_flashloan() public {
+    IERC20[] memory tokens = new IERC20[](1);
+    tokens[0] = IERC20(debtAsset);
+    uint256[] memory amounts = new uint256[](1);
+    amounts[0] = BORROW_AMOUNT;
+
+    bytes memory data = abi.encode(tokens, amounts);
+
+    IBalancerVault(flasher.getFlashloanSourceAddr(debtAsset)).flashLoan(this, tokens, amounts, data);
+
+    assertEq(IERC20(debtAsset).balanceOf(address(this)), 0);
+  }
+
+  // test rebalance a full position to another provider
+  function test_rebalanceWithRebalancer() public {
+    do_depositAndBorrow(DEPOSIT_AMOUNT, BORROW_AMOUNT, vault, ALICE);
+
+    vm.warp(block.timestamp + 13 seconds);
+    vm.roll(block.number + 1);
+
+    uint256 debt = vault.totalDebt();
+    uint256 assets = vault.totalAssets();
+
+    rebalancer.rebalanceVault(vault, assets, debt, aaveV2, compoundV3, flasher, true);
+
+    //issue with rounding
+    assertApproxEqAbs(aaveV2.getDepositBalance(address(vault), vault), 0, DEPOSIT_AMOUNT / 1000);
+    assertApproxEqAbs(aaveV2.getBorrowBalance(address(vault), vault), 0, DEPOSIT_AMOUNT / 1000);
+
+    //issue with rounding
+    assertApproxEqAbs(
+      compoundV3.getDepositBalance(address(vault), vault), assets, DEPOSIT_AMOUNT / 1000
+    );
+    assertApproxEqAbs(
+      compoundV3.getBorrowBalance(address(vault), vault), debt, BORROW_AMOUNT / 1000
+    );
+  }
+}

--- a/packages/protocol/test/forking/optimism/FlasherBalancerOptimism.t.sol
+++ b/packages/protocol/test/forking/optimism/FlasherBalancerOptimism.t.sol
@@ -53,14 +53,14 @@ contract FlasherBalancerOptimismForkingTest is Routines, ForkingSetup, IFlashLoa
   function receiveFlashLoan(
     IERC20[] memory, /*asset*/
     uint256[] memory, /*amount*/
-    uint256[] memory, /*initiator*/
+    uint256[] memory feeAmounts,
     bytes calldata data
   )
     external
   {
     (IERC20[] memory assets, uint256[] memory amounts) = abi.decode(data, (IERC20[], uint256[]));
 
-    assertEq(assets[0].balanceOf(address(this)), amounts[0]);
+    assertEq(assets[0].balanceOf(address(this)), amounts[0] + feeAmounts[0]);
 
     IERC20(assets[0]).transfer(msg.sender, amounts[0]);
   }
@@ -72,6 +72,9 @@ contract FlasherBalancerOptimismForkingTest is Routines, ForkingSetup, IFlashLoa
     amounts[0] = BORROW_AMOUNT;
 
     bytes memory data = abi.encode(tokens, amounts);
+
+    //deal premium
+    deal(address(debtAsset), address(this), flasher.computeFlashloanFee(debtAsset, BORROW_AMOUNT));
 
     IBalancerVault(flasher.getFlashloanSourceAddr(debtAsset)).flashLoan(this, tokens, amounts, data);
 

--- a/packages/protocol/test/forking/optimism/FlasherBalancerOptimism.t.sol
+++ b/packages/protocol/test/forking/optimism/FlasherBalancerOptimism.t.sol
@@ -1,0 +1,103 @@
+pragma solidity 0.8.15;
+
+import "forge-std/console.sol";
+import {Routines} from "../../utils/Routines.sol";
+import {ForkingSetup} from "../ForkingSetup.sol";
+import {ILendingProvider} from "../../../src/interfaces/ILendingProvider.sol";
+import {IVault} from "../../../src/interfaces/IVault.sol";
+import {FlasherBalancer} from "../../../src/flashloans/FlasherBalancer.sol";
+import {IFlasher} from "../../../src/interfaces/IFlasher.sol";
+import {RebalancerManager} from "../../../src/RebalancerManager.sol";
+import {IERC20} from "openzeppelin-contracts/contracts/token/ERC20/IERC20.sol";
+import {IBalancerVault} from "../../../src/interfaces/balancer/IBalancerVault.sol";
+import {IFlashLoanRecipient} from "../../../src/interfaces/balancer/IFlashLoanRecipient.sol";
+import {IronBankOptimism} from "../../../src/providers/optimism/IronBankOptimism.sol";
+import {AaveV3Optimism} from "../../../src/providers/optimism/AaveV3Optimism.sol";
+
+contract FlasherBalancerOptimismForkingTest is Routines, ForkingSetup, IFlashLoanRecipient {
+  ILendingProvider public ironBank;
+  ILendingProvider public aaveV3;
+
+  IFlasher public flasher;
+
+  RebalancerManager public rebalancer;
+
+  uint256 public constant DEPOSIT_AMOUNT = 1000e18;
+  uint256 public constant BORROW_AMOUNT = 100e6;
+
+  function setUp() public {
+    setUpFork(OPTIMISM_DOMAIN);
+
+    ironBank = new IronBankOptimism();
+    aaveV3 = new AaveV3Optimism();
+
+    flasher = new FlasherBalancer(0xBA12222222228d8Ba445958a75a0704d566BF2C8);
+
+    ILendingProvider[] memory providers = new ILendingProvider[](2);
+    providers[0] = ironBank;
+    providers[1] = aaveV3;
+
+    deploy(providers);
+
+    rebalancer = new RebalancerManager(address(chief));
+    _grantRoleChief(REBALANCER_ROLE, address(rebalancer));
+
+    bytes memory executionCall =
+      abi.encodeWithSelector(rebalancer.allowExecutor.selector, address(this), true);
+    _callWithTimelock(address(rebalancer), executionCall);
+
+    executionCall = abi.encodeWithSelector(chief.allowFlasher.selector, address(flasher), true);
+    _callWithTimelock(address(chief), executionCall);
+  }
+
+  function receiveFlashLoan(
+    IERC20[] memory, /*asset*/
+    uint256[] memory, /*amount*/
+    uint256[] memory, /*initiator*/
+    bytes calldata data
+  )
+    external
+  {
+    (IERC20[] memory assets, uint256[] memory amounts) = abi.decode(data, (IERC20[], uint256[]));
+
+    assertEq(assets[0].balanceOf(address(this)), amounts[0]);
+
+    IERC20(assets[0]).transfer(msg.sender, amounts[0]);
+  }
+
+  function test_flashloan() public {
+    IERC20[] memory tokens = new IERC20[](1);
+    tokens[0] = IERC20(debtAsset);
+    uint256[] memory amounts = new uint256[](1);
+    amounts[0] = BORROW_AMOUNT;
+
+    bytes memory data = abi.encode(tokens, amounts);
+
+    IBalancerVault(flasher.getFlashloanSourceAddr(debtAsset)).flashLoan(this, tokens, amounts, data);
+
+    assertEq(IERC20(debtAsset).balanceOf(address(this)), 0);
+  }
+
+  // test rebalance a full position to another provider
+  function test_rebalanceWithRebalancer() public {
+    do_depositAndBorrow(DEPOSIT_AMOUNT, BORROW_AMOUNT, vault, ALICE);
+
+    vm.warp(block.timestamp + 13 seconds);
+    vm.roll(block.number + 1);
+
+    uint256 debt = vault.totalDebt();
+    uint256 assets = vault.totalAssets();
+
+    rebalancer.rebalanceVault(vault, assets, debt, ironBank, aaveV3, flasher, true);
+
+    //issue with rounding
+    assertApproxEqAbs(ironBank.getDepositBalance(address(vault), vault), 0, DEPOSIT_AMOUNT / 1000);
+    assertApproxEqAbs(ironBank.getBorrowBalance(address(vault), vault), 0, DEPOSIT_AMOUNT / 1000);
+
+    //issue with rounding
+    assertApproxEqAbs(
+      aaveV3.getDepositBalance(address(vault), vault), assets, DEPOSIT_AMOUNT / 1000
+    );
+    assertApproxEqAbs(aaveV3.getBorrowBalance(address(vault), vault), debt, BORROW_AMOUNT / 1000);
+  }
+}

--- a/packages/protocol/test/forking/polygon/FlasherBalancerPolygon.t.sol
+++ b/packages/protocol/test/forking/polygon/FlasherBalancerPolygon.t.sol
@@ -62,14 +62,14 @@ contract FlasherBalancerPolygonForkingTest is Routines, ForkingSetup, IFlashLoan
   function receiveFlashLoan(
     IERC20[] memory, /*asset*/
     uint256[] memory, /*amount*/
-    uint256[] memory, /*initiator*/
+    uint256[] memory feeAmounts,
     bytes calldata data
   )
     external
   {
     (IERC20[] memory assets, uint256[] memory amounts) = abi.decode(data, (IERC20[], uint256[]));
 
-    assertEq(assets[0].balanceOf(address(this)), amounts[0]);
+    assertEq(assets[0].balanceOf(address(this)), amounts[0] + feeAmounts[0]);
 
     IERC20(assets[0]).transfer(msg.sender, amounts[0]);
   }
@@ -81,6 +81,9 @@ contract FlasherBalancerPolygonForkingTest is Routines, ForkingSetup, IFlashLoan
     amounts[0] = BORROW_AMOUNT;
 
     bytes memory data = abi.encode(tokens, amounts);
+
+    //deal premium
+    deal(address(debtAsset), address(this), flasher.computeFlashloanFee(debtAsset, BORROW_AMOUNT));
 
     IBalancerVault(flasher.getFlashloanSourceAddr(debtAsset)).flashLoan(this, tokens, amounts, data);
 

--- a/packages/protocol/test/forking/polygon/FlasherBalancerPolygon.t.sol
+++ b/packages/protocol/test/forking/polygon/FlasherBalancerPolygon.t.sol
@@ -1,0 +1,112 @@
+// SPDX-License-Identifier: UNLICENSED
+pragma solidity 0.8.15;
+
+import "forge-std/console.sol";
+import {Routines} from "../../utils/Routines.sol";
+import {ForkingSetup} from "../ForkingSetup.sol";
+import {ILendingProvider} from "../../../src/interfaces/ILendingProvider.sol";
+import {IVault} from "../../../src/interfaces/IVault.sol";
+import {FlasherBalancer} from "../../../src/flashloans/FlasherBalancer.sol";
+import {IFlasher} from "../../../src/interfaces/IFlasher.sol";
+import {RebalancerManager} from "../../../src/RebalancerManager.sol";
+import {IERC20} from "openzeppelin-contracts/contracts/token/ERC20/IERC20.sol";
+import {IBalancerVault} from "../../../src/interfaces/balancer/IBalancerVault.sol";
+import {IFlashLoanRecipient} from "../../../src/interfaces/balancer/IFlashLoanRecipient.sol";
+import {WePiggyPolygon} from "../../../src/providers/polygon/WePiggyPolygon.sol";
+import {DForcePolygon} from "../../../src/providers/polygon/DForcePolygon.sol";
+
+contract FlasherBalancerPolygonForkingTest is Routines, ForkingSetup, IFlashLoanRecipient {
+  ILendingProvider public dForce;
+  ILendingProvider public wePiggy;
+
+  IFlasher public flasher;
+
+  RebalancerManager public rebalancer;
+
+  uint256 public constant DEPOSIT_AMOUNT = 1000e18;
+  uint256 public constant BORROW_AMOUNT = 100e6;
+
+  function setUp() public {
+    setUpFork(POLYGON_DOMAIN);
+
+    dForce = new DForcePolygon();
+    wePiggy = new WePiggyPolygon();
+
+    flasher = new FlasherBalancer(0xBA12222222228d8Ba445958a75a0704d566BF2C8);
+
+    ILendingProvider[] memory providers = new ILendingProvider[](2);
+    providers[0] = dForce;
+    providers[1] = wePiggy;
+
+    deployVault(
+      registry[POLYGON_DOMAIN].wmatic,
+      registry[POLYGON_DOMAIN].usdc,
+      1250000000000000000,
+      100000000,
+      "WMATIC",
+      "USDC",
+      providers
+    );
+
+    rebalancer = new RebalancerManager(address(chief));
+    _grantRoleChief(REBALANCER_ROLE, address(rebalancer));
+
+    bytes memory executionCall =
+      abi.encodeWithSelector(rebalancer.allowExecutor.selector, address(this), true);
+    _callWithTimelock(address(rebalancer), executionCall);
+
+    executionCall = abi.encodeWithSelector(chief.allowFlasher.selector, address(flasher), true);
+    _callWithTimelock(address(chief), executionCall);
+  }
+
+  function receiveFlashLoan(
+    IERC20[] memory, /*asset*/
+    uint256[] memory, /*amount*/
+    uint256[] memory, /*initiator*/
+    bytes calldata data
+  )
+    external
+  {
+    (IERC20[] memory assets, uint256[] memory amounts) = abi.decode(data, (IERC20[], uint256[]));
+
+    assertEq(assets[0].balanceOf(address(this)), amounts[0]);
+
+    IERC20(assets[0]).transfer(msg.sender, amounts[0]);
+  }
+
+  function test_flashloan() public {
+    IERC20[] memory tokens = new IERC20[](1);
+    tokens[0] = IERC20(debtAsset);
+    uint256[] memory amounts = new uint256[](1);
+    amounts[0] = BORROW_AMOUNT;
+
+    bytes memory data = abi.encode(tokens, amounts);
+
+    IBalancerVault(flasher.getFlashloanSourceAddr(debtAsset)).flashLoan(this, tokens, amounts, data);
+
+    assertEq(IERC20(debtAsset).balanceOf(address(this)), 0);
+  }
+
+  // test rebalance a full position to another provider
+  function test_rebalanceWithRebalancer() public {
+    do_depositAndBorrow(DEPOSIT_AMOUNT, BORROW_AMOUNT, vault, ALICE);
+
+    vm.warp(block.timestamp + 13 seconds);
+    vm.roll(block.number + 1);
+
+    uint256 debt = vault.totalDebt();
+    uint256 assets = vault.totalAssets();
+
+    rebalancer.rebalanceVault(vault, assets, debt, dForce, wePiggy, flasher, true);
+
+    //issue with rounding
+    assertApproxEqAbs(dForce.getDepositBalance(address(vault), vault), 0, DEPOSIT_AMOUNT / 1000);
+    assertApproxEqAbs(dForce.getBorrowBalance(address(vault), vault), 0, DEPOSIT_AMOUNT / 1000);
+
+    //issue with rounding
+    assertApproxEqAbs(
+      wePiggy.getDepositBalance(address(vault), vault), assets, DEPOSIT_AMOUNT / 1000
+    );
+    assertApproxEqAbs(wePiggy.getBorrowBalance(address(vault), vault), debt, BORROW_AMOUNT / 1000);
+  }
+}


### PR DESCRIPTION
Integrating Balancer as Flashloan provider in every chain we currently have. Turns out they have it deployed on mainnet, arbitrum, optimism, polygon and even gnosis! Btw, big plus their fee being 0 cost which means after this PR, we will have a flasher on every chain with 0 cost :)
I took advantage of the tests done previously for FlasherAaveV3 (which include a super simple flashloan and a rebalance with Rebalancer Manager which is the real use case scenario)