### PR TITLE
Align license and pragma

### DIFF
--- a/packages/protocol/src/abstracts/EIP712.sol
+++ b/packages/protocol/src/abstracts/EIP712.sol
@@ -1,6 +1,5 @@
-// SPDX-License-Identifier: MIT
-
-pragma solidity ^0.8.15;
+// SPDX-License-Identifier: GPL-3.0-or-later
+pragma solidity 0.8.15;
 
 import {ECDSA} from "openzeppelin-contracts/contracts/utils/cryptography/ECDSA.sol";
 

--- a/packages/protocol/src/interfaces/dforce/IGenIToken.sol
+++ b/packages/protocol/src/interfaces/dforce/IGenIToken.sol
@@ -1,6 +1,6 @@
 // SPDX-License-Identifier: MIT
 
-pragma solidity ^0.8.15;
+pragma solidity 0.8.15;
 
 import {IERC20} from "openzeppelin-contracts/contracts/token/ERC20/IERC20.sol";
 

--- a/packages/protocol/src/interfaces/dforce/IIERC20.sol
+++ b/packages/protocol/src/interfaces/dforce/IIERC20.sol
@@ -1,6 +1,6 @@
 // SPDX-License-Identifier: MIT
 
-pragma solidity ^0.8.15;
+pragma solidity 0.8.15;
 
 import {IERC20} from "openzeppelin-contracts/contracts/token/ERC20/IERC20.sol";
 import {IGenIToken} from "./IGenIToken.sol";

--- a/packages/protocol/src/interfaces/dforce/IIETH.sol
+++ b/packages/protocol/src/interfaces/dforce/IIETH.sol
@@ -1,6 +1,6 @@
 // SPDX-License-Identifier: MIT
 
-pragma solidity ^0.8.15;
+pragma solidity 0.8.15;
 
 import {IERC20} from "openzeppelin-contracts/contracts/token/ERC20/IERC20.sol";
 import {IGenIToken} from "./IGenIToken.sol";

--- a/packages/protocol/src/interfaces/morpho/IMorpho.sol
+++ b/packages/protocol/src/interfaces/morpho/IMorpho.sol
@@ -1,5 +1,5 @@
-// SPDX-License-Identifier: GNU AGPLv3
-pragma solidity ^0.8.0;
+// SPDX-License-Identifier: GPL-3.0-or-later
+pragma solidity 0.8.15;
 
 interface IMorpho {
   /// USERS ///

--- a/packages/protocol/src/mocks/MockAddrMapper.sol
+++ b/packages/protocol/src/mocks/MockAddrMapper.sol
@@ -1,4 +1,4 @@
-// SPDX-License-Identifier: GPL-3.0-or-later
+// SPDX-License-Identifier: UNLICENSED
 pragma solidity 0.8.15;
 
 import {Ownable} from "openzeppelin-contracts/contracts/access/Ownable.sol";

--- a/packages/protocol/src/mocks/MockRebalancerManager.sol
+++ b/packages/protocol/src/mocks/MockRebalancerManager.sol
@@ -1,4 +1,4 @@
-// SPDX-License-Identifier: BUSL-1.1
+// SPDX-License-Identifier: UNLICENSED
 pragma solidity 0.8.15;
 
 import {IVault} from "../interfaces/IVault.sol";

--- a/packages/protocol/src/swappers/UniswapV2Swapper.sol
+++ b/packages/protocol/src/swappers/UniswapV2Swapper.sol
@@ -1,4 +1,4 @@
-// SPDX-License-Identifier: UNLICENSED
+// SPDX-License-Identifier: GPL-3.0-or-later
 pragma solidity 0.8.15;
 
 /**


### PR DESCRIPTION
Ensure licenses align:

- Core business logic contracts-> // SPDX-License-Identifier: BUSL-1.1 (what we could call proprietary)
- General logic to interact with external contracts-> // SPDX-License-Identifier: GPL-3.0-or-later (what we took from others, modified, or adapted to interact with external protocols)
- testing and mocking contracts -> // SPDX-License-Identifier: UNLICENSED (no need to provide a specific license for this)