### PR TITLE
ConnextHandler Suggestions

### DIFF
--- a/packages/protocol/src/routers/ConnextRouter.sol
+++ b/packages/protocol/src/routers/ConnextRouter.sol
@@ -16,6 +16,7 @@ import {ConnextHandler} from "./ConnextHandler.sol";
 import {BaseRouter} from "../abstracts/BaseRouter.sol";
 import {IWETH9} from "../abstracts/WETH9.sol";
 import {IVault} from "../interfaces/IVault.sol";
+import {IVaultPermissions} from "../interfaces/IVaultPermissions.sol";
 import {IChief} from "../interfaces/IChief.sol";
 import {IRouter} from "../interfaces/IRouter.sol";
 import {IFlasher} from "../interfaces/IFlasher.sol";
@@ -371,10 +372,15 @@ contract ConnextRouter is BaseRouter, IXReceiver {
       // For WithdrawEth
       (, address receiver) = abi.decode(args[0], (uint256, address));
       beneficiary = receiver;
+    } else if (actions[0] == Action.PermitBorrow || actions[0] == Action.PermitWithdraw) {
+      (, address owner,,,,,,) = abi.decode(
+        args[0], (IVaultPermissions, address, address, uint256, uint256, uint8, bytes32, bytes32)
+      );
+      beneficiary = owner;
     } else if (actions[0] == Action.Flashloan) {
       (,,,, bytes memory requestorCalldata) =
         abi.decode(args[0], (IFlasher, address, uint256, address, bytes));
-      _getBeneficiaryFromCalldata(requestorCalldata);
+      beneficiary = _getBeneficiaryFromCalldata(requestorCalldata);
     } else if (actions[0] == Action.Swap) {
       /// @dev swap cannot be actions[0].
       revert BaseRouter__bundleInternal_swapNotFirstAction();

--- a/packages/protocol/test/forking/goerli/ConnextRouter.t.sol
+++ b/packages/protocol/test/forking/goerli/ConnextRouter.t.sol
@@ -353,7 +353,7 @@ contract ConnextRouterForkingTest is Routines, ForkingSetup {
       ALICE, ALICE_PK, address(connextRouter), ALICE, borrowAmount, 0, address(vault)
     );
 
-    connextHandler.executeFailedWithUpdatedArgs(transferId, transfer.args);
+    connextHandler.executeFailedWithUpdatedArgs(transferId, transfer.actions, transfer.args);
     // Assert Alice has funds deposited in the vault
     assertGt(vault.balanceOf(ALICE), 0);
     // Assert Alice was able to borrow from the vault

--- a/packages/protocol/test/forking/goerli/ConnextRouter.t.sol
+++ b/packages/protocol/test/forking/goerli/ConnextRouter.t.sol
@@ -345,7 +345,7 @@ contract ConnextRouterForkingTest is Routines, ForkingSetup {
     // Ensure calldata is fixed
     // In this case the badCalldata previously had sender as address(0).
     // The ConnextHhander replaces `sender` with its address when recording the failed transfer.
-    ConnextHandler.FailedTransfer memory transfer = connextHandler.getFailedTransfer(transferId);
+    ConnextHandler.FailedTxn memory transfer = connextHandler.getFailedTransaction(transferId);
     bytes memory newArg0 = transfer.args[0];
     (,,, address sender) = abi.decode(newArg0, (IVault, uint256, address, address));
     assert(sender == address(connextHandler));


### PR DESCRIPTION
@DaigaroCota These are my suggestions about #285 

1. you talk about transfers; I think it's more accurate to call them transactions
2. removed the error from the constructor. I think if we pass the zero address, it will fail anyway because of the casting to "ConnextRouter" (I'm not super sure about that, though)
3. Why do we bother to replace `sender` in `recordFailed()`, when in `executeFailedWithUpdatedArgs()` we can pass whatever `args` we want?