### PR TITLE
Review and suggestions for Routing Modal

### DIFF
--- a/packages/frontend/components/Borrow/Fees.tsx
+++ b/packages/frontend/components/Borrow/Fees.tsx
@@ -34,7 +34,7 @@ export const Fees = () => {
         {transactionMeta.status === "ready" && (
           <Stack direction="row" alignItems="center" maxHeight="22px">
             <Typography variant="small">
-              {`~$${transactionMeta.bridgeFees} + gas`}
+              {`~$${transactionMeta.bridgeFee.toFixed(2)} + gas`}
             </Typography>
             {show ? <KeyboardArrowUpIcon /> : <KeyboardArrowDownIcon />}
           </Stack>
@@ -53,7 +53,10 @@ export const Fees = () => {
       </Stack>
 
       <Collapse in={show} sx={{ width: "100%" }}>
-        <Fee label="Bridges fees" value={`~$${transactionMeta.bridgeFees}`} />
+        <Fee
+          label="Bridge fee"
+          value={`~$${transactionMeta.bridgeFee.toFixed(2)}`}
+        />
         <Fee
           label="Est. processing time"
           value={`~${transactionMeta.estimateTime / 60} minutes`}

--- a/packages/frontend/helpers/borrowService.ts
+++ b/packages/frontend/helpers/borrowService.ts
@@ -1,9 +1,10 @@
-import { parseUnits } from "ethers/lib/utils"
+import { formatUnits, parseUnits } from "ethers/lib/utils"
 
 import {
   Address,
   BorrowingVault,
   RouterActionParams,
+  RoutingStep,
   RoutingStepDetails,
   Token,
 } from "@x-fuji/sdk"
@@ -12,7 +13,7 @@ import { sdk } from "../services/sdk"
 export type RouteMeta = {
   //gasFees: number
   estimateSlippage: number
-  bridgeFees: number
+  bridgeFee: number
   estimateTime: number
   steps: RoutingStepDetails[]
   actions: RouterActionParams[]
@@ -53,11 +54,17 @@ export const fetchRoutes = async (
     const { bridgeFee, estimateSlippage, estimateTime, actions, steps } =
       preview
 
+    const bridgeStep = steps.filter((s) => s.step === RoutingStep.X_TRANSFER)[0]
+    const _bridgeFee = bridgeStep
+      ? formatUnits(bridgeFee, bridgeStep.token?.decimals ?? 18)
+      : "0"
+
     result.data = {
       address: vault.address.value,
       recommended,
-      bridgeFees: bridgeFee.toNumber(),
-      estimateSlippage: estimateSlippage.toNumber(),
+      bridgeFee: Number(_bridgeFee),
+      // slippage is in basis points
+      estimateSlippage: estimateSlippage.toNumber() / 100,
       estimateTime,
       actions,
       steps,

--- a/packages/frontend/store/borrow.store.ts
+++ b/packages/frontend/store/borrow.store.ts
@@ -57,7 +57,7 @@ type BorrowState = {
   transactionMeta: {
     status: FetchStatus
     gasFees: number // TODO: cannot estimat gas fees until the user has approved AND permit fuji to use its fund
-    bridgeFees: number
+    bridgeFee: number
     estimateTime: number
     steps: RoutingStepDetails[]
   }
@@ -148,7 +148,7 @@ const initialState: BorrowState = {
 
   transactionMeta: {
     status: "initial",
-    bridgeFees: 0,
+    bridgeFee: 0,
     gasFees: 0,
     estimateTime: 0,
     steps: [],
@@ -397,7 +397,7 @@ export const useBorrow = create<BorrowStore>()(
 
         const doUpdateTxMeta = (
           status: FetchStatus,
-          bridgeFees: number,
+          bridgeFee: number,
           estimateTime: number,
           steps: RoutingStepDetails[],
           actions: RouterActionParams[],
@@ -406,7 +406,7 @@ export const useBorrow = create<BorrowStore>()(
           set(
             produce((state: BorrowState) => {
               state.transactionMeta.status = status
-              state.transactionMeta.bridgeFees = bridgeFees
+              state.transactionMeta.bridgeFee = bridgeFee
               state.transactionMeta.estimateTime = estimateTime
               state.transactionMeta.steps = steps
               state.needPermit = Sdk.needSignature(actions)
@@ -421,7 +421,7 @@ export const useBorrow = create<BorrowStore>()(
         if (route) {
           doUpdateTxMeta(
             "ready",
-            route.bridgeFees,
+            route.bridgeFee,
             route.estimateTime,
             route.steps,
             route.actions,
@@ -449,11 +449,10 @@ export const useBorrow = create<BorrowStore>()(
         )
 
         try {
+          const vaults = get().availableVaults
           const results = await Promise.all(
-            [vault].map(async (v) => {
-              const [selectedVault] = await get().availableVaults
-              const recommended =
-                vault.address.value === selectedVault.address.value
+            vaults.map((v, i) => {
+              const recommended = i === 0
 
               return fetchRoutes(
                 v,
@@ -475,7 +474,7 @@ export const useBorrow = create<BorrowStore>()(
           if (!selectedValue.data) {
             throw "Data not found"
           }
-          const { bridgeFees, estimateTime, actions, steps } =
+          const { bridgeFee, estimateTime, actions, steps } =
             selectedValue.data as RouteMeta
 
           if (!actions.length) {
@@ -488,7 +487,7 @@ export const useBorrow = create<BorrowStore>()(
 
           doUpdateTxMeta(
             "ready",
-            bridgeFees,
+            bridgeFee,
             estimateTime,
             steps,
             actions,


### PR DESCRIPTION
Here are the changes I suggest for #286 

### Majors
- loop through availableVaults to get a route for each vault instead only for the first one
- in RouteCard: use start and end step instead of relying on the `collateralInput` and `debtInput`. The point is to have the bridged and received amounts calculated by the sdk
- when slippage > 0, that means user "suffer" from it so it needs to be in red
- rename `bridgeFees` to `bridgeFee` to be consistent with returned name from sdk
- `bridgeFee` needs to be formatted with the decimals of the asset being bridged
- use `RoutingStep` enum values from the SDK instead of strings
- added and changed tooltips that weren't in the designs

### Minors
-  why don't you use array.find() rather than array.filter()[0]
-  we can use Address.from(ADDR) instead of new Address(ADDR)