### PR TITLE
Fix approvals and vault providers

### DIFF
--- a/packages/frontend/components/Borrow/ApprovalModal.tsx
+++ b/packages/frontend/components/Borrow/ApprovalModal.tsx
@@ -24,8 +24,7 @@ export default function ApprovalModal(props: ApprovalModalProps) {
   const theme = useTheme()
   const isMobile = useMediaQuery(theme.breakpoints.down("sm"))
   const collateralAllowance = useBorrow((state) => state.collateralAllowance)
-  const collateral = useBorrow((state) => state.position.collateral)
-  const meta = useBorrow((state) => state.transactionMeta)
+  const collateralInput = useBorrow((state) => state.collateralInput)
 
   const [infiniteApproval, setInfiniteApproval] = useState(false)
   const handleChange = (event: React.ChangeEvent<HTMLInputElement>) => {
@@ -34,9 +33,7 @@ export default function ApprovalModal(props: ApprovalModalProps) {
 
   const amount = infiniteApproval
     ? Number.MAX_SAFE_INTEGER
-    : collateral.amount +
-      meta.bridgeFee / collateral.usdValue +
-      meta.gasFees / collateral.usdValue
+    : parseFloat(collateralInput)
 
   const allow = useBorrow((state) => state.allow)
   const handleAllow = () => allow(amount, props.handleClose)
@@ -83,8 +80,8 @@ export default function ApprovalModal(props: ApprovalModalProps) {
         </Typography>
 
         <Typography mt="1rem">
-          Otherwise only the exact amount for this transaction will be allowed
-          to be transfered from your wallet
+          Otherwise, only the exact amount for this transaction will be allowed
+          to be transfered from your wallet.
         </Typography>
         <Stack
           direction="row"

--- a/packages/frontend/components/Borrow/Borrow.tsx
+++ b/packages/frontend/components/Borrow/Borrow.tsx
@@ -129,7 +129,7 @@ export default function Borrow() {
     )
   } else if (
     collateralAllowance?.value !== undefined &&
-    collateralAllowance.value < collateral.amount
+    collateralAllowance.value < collateralAmount
   ) {
     button = (
       <Button

--- a/packages/frontend/components/Borrow/Overview.tsx
+++ b/packages/frontend/components/Borrow/Overview.tsx
@@ -32,11 +32,10 @@ export default function Overview() {
   const liquidationDiff = useBorrow((state) => state.position.liquidationDiff)
   const collateral = useBorrow((state) => state.position.collateral)
   const debt = useBorrow((state) => state.position.debt)
-  const providers = useBorrow((state) => state.position.providers)
+  const allProviders = useBorrow((state) => state.allProviders)
   const vault = useBorrow((state) => state.position.vault)
-  const availableVaults = useBorrow((state) => state.availableVaults)
-  const availableRoutes = useBorrow((state) => state.availableRoutes)
-  const changeActiveVault = useBorrow((state) => state.changeActiveVault)
+  const providers =
+    allProviders && vault ? allProviders[vault.address.value] : []
 
   return (
     <Grid container alignItems="center" justifyContent="space-between">
@@ -56,47 +55,36 @@ export default function Overview() {
             height="40px"
           >
             <Typography variant="body2">Overview</Typography>
-            {availableRoutes.length > 0 &&
-              availableRoutes.find((r) => r.address === vault?.address.value) &&
-              vault && (
-                <Stack direction="row" alignItems="center">
-                  <Tooltip
-                    arrow
-                    title={
-                      <span>
-                        We take into account variables such as liquidity, audits
-                        and team behind each protocol, you can read more on our
-                        risk framework{" "}
-                        <Link
-                          href="https://docs.fujidao.org/"
-                          target="_blank"
-                          rel="noreferrer"
-                        >
-                          <u> here</u>
-                        </Link>
-                      </span>
-                    }
-                    placement="top"
-                  >
-                    <InfoOutlinedIcon
-                      sx={{ fontSize: "1rem", color: palette.info.main }}
-                    />
-                  </Tooltip>
-                  <Typography variant="smallDark" ml={0.5} mr={1}>
-                    Safety rating:
-                  </Typography>
-                  <VaultsMenu
-                    vault={vault}
-                    routes={availableRoutes}
-                    onSelection={(route) => {
-                      const v = availableVaults.filter(
-                        (v) => v.address.value === route.address
-                      )[0]
-                      changeActiveVault(v)
-                    }}
+            {providers && vault && (
+              <Stack direction="row" alignItems="center">
+                <Tooltip
+                  arrow
+                  title={
+                    <span>
+                      We take into account variables such as liquidity, audits
+                      and team behind each protocol, you can read more on our
+                      risk framework{" "}
+                      <Link
+                        href="https://docs.fujidao.org/"
+                        target="_blank"
+                        rel="noreferrer"
+                      >
+                        <u> here</u>
+                      </Link>
+                    </span>
+                  }
+                  placement="top"
+                >
+                  <InfoOutlinedIcon
+                    sx={{ fontSize: "1rem", color: palette.info.main }}
                   />
-                </Stack>
-              )}
+                </Tooltip>
+                <Typography variant="smallDark" ml={0.5} mr={1}>
+                  Safety rating:
+                </Typography>
+                <VaultsMenu vault={vault} providers={providers} />
+              </Stack>
+            )}
           </Stack>
           <Divider sx={{ mt: "1rem", mb: "1.5rem" }} />
 
@@ -205,7 +193,7 @@ export default function Overview() {
           <Grid container justifyContent="space-between">
             <Grid item>
               <Typography variant="smallDark">
-                Collateral will be deposit into
+                Collateral will be deposited into
               </Typography>
             </Grid>
             <Grid item>
@@ -218,7 +206,7 @@ export default function Overview() {
                   />
 
                   <Typography ml="0.375rem" variant="small">
-                    {providers[0].name}
+                    {providers.find((p) => p.active)?.name}
                   </Typography>
                 </Grid>
               ) : (

--- a/packages/frontend/components/Borrow/VaultsMenu.tsx
+++ b/packages/frontend/components/Borrow/VaultsMenu.tsx
@@ -1,45 +1,45 @@
 import React from "react"
-import { Box, Button, Chip, Fade, Menu, MenuItem, Stack } from "@mui/material"
-import KeyboardArrowDownIcon from "@mui/icons-material/KeyboardArrowDown"
-import CheckIcon from "@mui/icons-material/Check"
+import { Box, Chip, Stack } from "@mui/material"
+// import { Box, Button, Chip, Fade, Menu, MenuItem, Stack } from "@mui/material"
+// import KeyboardArrowDownIcon from "@mui/icons-material/KeyboardArrowDown"
+// import CheckIcon from "@mui/icons-material/Check"
 import { BorrowingVault, LendingProviderDetails } from "@x-fuji/sdk"
 
 import { ProviderIcon } from "../Shared/Icons"
-import { providersForRoute, RouteMeta } from "../../helpers/borrow"
 
 type VaultsMenuProps = {
   vault: BorrowingVault
-  routes: RouteMeta[]
-  onSelection: (route: RouteMeta) => void
+  providers: LendingProviderDetails[]
 }
 
 function VaultsMenu(props: VaultsMenuProps) {
-  const [anchorEl, setAnchorEl] = React.useState<null | HTMLElement>(null)
-  const open = (event: React.MouseEvent<HTMLButtonElement>) => {
-    setAnchorEl(event.currentTarget)
-  }
-  const select = (route: RouteMeta) => {
-    props.onSelection(route)
-    setAnchorEl(null)
-  }
+  // const [anchorEl, setAnchorEl] = React.useState<null | HTMLElement>(null)
+  // const open = (event: React.MouseEvent<HTMLButtonElement>) => {
+  // setAnchorEl(event.currentTarget)
+  // }
+  // const select = (route: RouteMeta) => {
+  // props.onSelection(route)
+  // setAnchorEl(null)
+  // }
 
-  const selectedRoute = props.routes.find(
-    (r) => r.address === props.vault.address.value
-  )
-  if (!selectedRoute) return <></>
+  //const selectedRoute = props.routes.find(
+  //(r) => r.address === props.vault.address.value
+  //)
+  //if (!selectedRoute) return <></>
   // if (props.routes.length < 2) {
   return (
     <Stack direction="row" alignItems="center" spacing={1}>
       <Chip variant="success" label="A+" />
       <Box display="flex" alignItems="center">
-        {providersForRoute(selectedRoute).map((p) => (
-          <ProviderIcon
-            key={p.name}
-            providerName={p.name}
-            height={16}
-            width={16}
-          />
-        ))}
+        {props.providers &&
+          props.providers.map((p) => (
+            <ProviderIcon
+              key={p.name}
+              providerName={p.name}
+              height={16}
+              width={16}
+            />
+          ))}
       </Box>
     </Stack>
   )

--- a/packages/frontend/components/Borrow/VaultsMenu.tsx
+++ b/packages/frontend/components/Borrow/VaultsMenu.tsx
@@ -12,6 +12,11 @@ type VaultsMenuProps = {
   providers: LendingProviderDetails[]
 }
 
+// Commenting out most of this component and let it
+// display only the rating and the providers of the activeVault.
+// In the future, it should be turned again into a menu and made
+// responsible to select vaults according their safety rating.
+
 function VaultsMenu(props: VaultsMenuProps) {
   // const [anchorEl, setAnchorEl] = React.useState<null | HTMLElement>(null)
   // const open = (event: React.MouseEvent<HTMLButtonElement>) => {

--- a/packages/frontend/helpers/borrow.ts
+++ b/packages/frontend/helpers/borrow.ts
@@ -3,7 +3,6 @@ import { formatUnits, parseUnits } from "ethers/lib/utils"
 import {
   Address,
   BorrowingVault,
-  LendingProviderDetails,
   RouterActionParams,
   RoutingStep,
   RoutingStepDetails,
@@ -76,20 +75,6 @@ export const fetchRoutes = async (
     if (e instanceof Error) result.error = e
   }
   return result
-}
-
-export const providersForRoute = (
-  route: RouteMeta
-): LendingProviderDetails[] => {
-  const unique: LendingProviderDetails[] = []
-  const providers: Record<string, boolean> = {}
-  route.steps.forEach((s) => {
-    if (s.lendingProvider && !providers[s.lendingProvider?.name]) {
-      unique.push(s.lendingProvider)
-      providers[s.lendingProvider?.name] = true
-    }
-  })
-  return unique
 }
 
 export const recommendedLTV = (ltvMax: number): number => {

--- a/packages/frontend/store/borrow.store.ts
+++ b/packages/frontend/store/borrow.store.ts
@@ -346,9 +346,7 @@ export const useBorrow = create<BorrowStore>()(
         )
         try {
           const res = await sdk.getAllowanceFor(token, new Address(address))
-          const value = parseFloat(
-            ethers.utils.formatUnits(res, token.decimals)
-          )
+          const value = parseFloat(formatUnits(res, token.decimals))
           set({ collateralAllowance: { status: "ready", value } })
         } catch (e) {
           // TODO: how to handle the case where we can't fetch allowance ?
@@ -574,8 +572,9 @@ export const useBorrow = create<BorrowStore>()(
           const approval = await contracts.ERC20__factory.connect(
             token.address.value,
             owner
-          ).approve(spender, parseUnits(amount.toString()))
+          ).approve(spender, parseUnits(amount.toString(), token.decimals))
           await approval.wait()
+
           set({ collateralAllowance: { status: "ready", value: amount } })
           afterSuccess && afterSuccess()
         } catch (e) {


### PR DESCRIPTION
### Suggested changes:

- use `allProvders` to get access to the active vault's providers to display in "VaultsMenu" comp
- comment out unused elements of "VaultsMenu"
- temp fix of the approval process
- in Borrow/Overview, display the name of the active provider and not just the first one