### PR TITLE
Show warning in tx modal after 10 minutes

### DIFF
--- a/packages/frontend/components/Borrow/TransactionModal.tsx
+++ b/packages/frontend/components/Borrow/TransactionModal.tsx
@@ -27,7 +27,7 @@ import { formatUnits } from 'ethers/lib/utils';
 import { useRouter } from 'next/router';
 import { useState } from 'react';
 
-import { PATH } from '../../constants';
+import { CONNEXT_WARNING_DURATION, PATH } from '../../constants';
 import { chainName } from '../../helpers/chains';
 import { transactionUrl } from '../../helpers/chains';
 import { HistoryEntryStatus, validSteps } from '../../helpers/history';
@@ -39,6 +39,7 @@ import { useAuth } from '../../store/auth.store';
 import { useHistory } from '../../store/history.store';
 import AddTokenButton from '../Shared/AddTokenButton';
 import { NetworkIcon } from '../Shared/Icons';
+import WarningInfo from '../Shared/WarningInfo';
 
 type TransactionModalProps = {
   hash?: string;
@@ -60,8 +61,8 @@ function TransactionModal({ hash, currentPage }: TransactionModalProps) {
     entry?.steps.find((s) => s.step === RoutingStep.BORROW) ||
     entry?.steps.find((s) => s.step === RoutingStep.WITHDRAW);
 
-  const connextScanLink = entry?.connextTransferId
-    ? `https://amarok.connextscan.io/tx/${entry.connextTransferId}`
+  const connextScanLink = entry?.connext
+    ? `https://amarok.connextscan.io/tx/${entry.connext.transferId}`
     : undefined;
 
   if (!entry) {
@@ -248,12 +249,29 @@ function TransactionModal({ hash, currentPage }: TransactionModalProps) {
           </Stepper>
         </DialogContent>
         {entry.status === HistoryEntryStatus.ONGOING && (
-          <Card variant="outlined" sx={{ mt: '2rem', maxWidth: '100%' }}>
-            <Typography variant="small" textAlign="center" fontSize="0.875rem">
-              This step takes a few minutes to process. If you close this
-              window, your transaction will still be processed.
-            </Typography>
-          </Card>
+          <>
+            <Card variant="outlined" sx={{ mt: '2rem', maxWidth: '100%' }}>
+              <Typography
+                variant="small"
+                textAlign="center"
+                fontSize="0.875rem"
+              >
+                This step takes a few minutes to process. If you close this
+                window, your transaction will still be processed.
+              </Typography>
+            </Card>
+            {entry.connext &&
+              Date.now() - entry.connext.timestamp >
+                CONNEXT_WARNING_DURATION && (
+                <Box sx={{ marginBottom: 2, marginTop: 2 }}>
+                  <WarningInfo
+                    text={
+                      'The operation takes longer than expected. You can visit ConnextScan below to check for potential issues. You might be required to connect with the same address and perform an action.'
+                    }
+                  />
+                </Box>
+              )}
+          </>
         )}
         {connextScanLink && (
           <Stack sx={{ mt: '1rem' }} spacing={1}>

--- a/packages/frontend/constants/common.ts
+++ b/packages/frontend/constants/common.ts
@@ -1,4 +1,4 @@
-export const CONFIRMATIONS = 3;
+export const CONNEXT_WARNING_DURATION = 1000 * 60 * 10; // 10 minutes
 
 export const BALANCE_POLLING_INTERVAL = 15000;
 

--- a/packages/frontend/helpers/history.ts
+++ b/packages/frontend/helpers/history.ts
@@ -28,11 +28,16 @@ export type HistoryEntryChain = {
   hash?: string;
 };
 
+export type HistoryEntryConnext = {
+  transferId: string;
+  timestamp: number;
+};
+
 export type HistoryEntry = {
   hash: string;
   steps: HistoryRoutingStep[];
   status: HistoryEntryStatus;
-  connextTransferId?: string;
+  connext?: HistoryEntryConnext;
   vaultAddress?: string;
   sourceChain: HistoryEntryChain;
   isCrossChain: boolean; // Convenience

--- a/packages/frontend/store/history.store.ts
+++ b/packages/frontend/store/history.store.ts
@@ -219,10 +219,12 @@ export const useHistory = create<HistoryStore>()(
                   if (
                     crosschainResult.data.connextTransferId &&
                     crosschainResult.data.status !== ConnextTxStatus.UNKNOWN &&
-                    !e.connextTransferId
+                    !e.connext
                   ) {
-                    e.connextTransferId =
-                      crosschainResult.data.connextTransferId;
+                    e.connext = {
+                      transferId: crosschainResult.data.connextTransferId,
+                      timestamp: Date.now(),
+                    };
                   }
                   if (!e.destinationChain) return;
                   if (


### PR DESCRIPTION
If a cross-chain operation has taken more than 10', show a warning in the tx modal letting the user know he should check if everything is ok