### PR TITLE
Remove redundant xreceive slippage check

### DIFF
--- a/packages/protocol/test/forking/ForkingSetup.sol
+++ b/packages/protocol/test/forking/ForkingSetup.sol
@@ -338,8 +338,7 @@ contract ForkingSetup is CoreRoles, Test, ChainlinkFeeds {
     uint256 amount,
     uint256 borrowAmount,
     address router,
-    address vault_,
-    uint256 slippage
+    address vault_
   )
     internal
     returns (bytes memory callData)
@@ -368,7 +367,7 @@ contract ForkingSetup is CoreRoles, Test, ChainlinkFeeds {
       actionArgsHash // actions args hash
     );
 
-    callData = abi.encode(actions, args, slippage);
+    callData = abi.encode(actions, args);
   }
 
   function _getDepositAndBorrow(

--- a/packages/protocol/test/forking/optimism-goerli/ConnextRouter.t.sol
+++ b/packages/protocol/test/forking/optimism-goerli/ConnextRouter.t.sol
@@ -77,10 +77,6 @@ contract ConnextRouterForkingTest is Routines, ForkingSetup {
     collateralAsset = 0x68Db1c8d85C09d546097C65ec7DCBFF4D6497CbF;
     deal(collateralAsset, ALICE, amount);
 
-    // The maximum slippage acceptable, in BPS, due to the Connext bridging mechanics
-    // Eg. 0.05% slippage threshold will be 5.
-    uint256 slippageThreshold = 0;
-
     uint32 destDomain = GOERLI_DOMAIN;
 
     vm.startPrank(ALICE);
@@ -98,7 +94,7 @@ contract ConnextRouterForkingTest is Routines, ForkingSetup {
     destActions[0] = IRouter.Action.Deposit;
     destArgs[0] = abi.encode(address(vault), amount, ALICE, address(connextRouter));
 
-    bytes memory destCallData = abi.encode(destActions, destArgs, slippageThreshold);
+    bytes memory destCallData = abi.encode(destActions, destArgs);
     args[0] = abi.encode(destDomain, 30, collateralAsset, amount, ALICE, destCallData);
 
     vm.expectEmit(false, false, false, false);
@@ -111,18 +107,8 @@ contract ConnextRouterForkingTest is Routines, ForkingSetup {
     uint256 amount = 0.2 ether;
     uint256 borrowAmount = 100e6;
 
-    // The maximum slippage acceptable, in BPS, due to the Connext bridging mechanics
-    // Eg. 0.05% slippage threshold will be 5.
-    uint256 slippageThreshold = 0;
-
     bytes memory callData = _getDepositAndBorrowCallData(
-      ALICE,
-      ALICE_PK,
-      amount,
-      borrowAmount,
-      address(connextRouter),
-      address(vault),
-      slippageThreshold
+      ALICE, ALICE_PK, amount, borrowAmount, address(connextRouter), address(vault)
     );
 
     vm.expectEmit(true, true, true, false);
@@ -151,18 +137,8 @@ contract ConnextRouterForkingTest is Routines, ForkingSetup {
     uint256 amount = 2 ether;
     uint256 borrowAmount = 1000e6;
 
-    // The maximum slippage acceptable, in BPS, due to the Connext bridging mechanics
-    // Eg. 0.05% slippage threshold will be 5.
-    uint256 slippageThreshold = 5;
-
     bytes memory callData = _getDepositAndBorrowCallData(
-      ALICE,
-      ALICE_PK,
-      amount,
-      borrowAmount,
-      address(connextRouter),
-      address(vault),
-      slippageThreshold
+      ALICE, ALICE_PK, amount, borrowAmount, address(connextRouter), address(vault)
     );
 
     vm.expectEmit(true, true, true, false);
@@ -199,13 +175,9 @@ contract ConnextRouterForkingTest is Routines, ForkingSetup {
     uint256 amount = 2 ether;
     uint256 borrowAmount = 1000e6;
 
-    // The maximum slippage acceptable, in BPS, due to the Connext bridging mechanics
-    // Eg. 0.05% slippage threshold will be 5.
-    uint256 slippageThreshold = 5;
-
     // This calldata has to fail and funds stay at the router.
     bytes memory failingCallData = _getDepositAndBorrowCallData(
-      ALICE, ALICE_PK, amount, borrowAmount, address(0), address(vault), slippageThreshold
+      ALICE, ALICE_PK, amount, borrowAmount, address(0), address(vault)
     );
 
     // Send directly the bridged funds to our router thus mocking Connext behavior
@@ -225,13 +197,7 @@ contract ConnextRouterForkingTest is Routines, ForkingSetup {
     // Attacker attemps to take funds, BOB
     address attacker = BOB;
     bytes memory attackCallData = _getDepositAndBorrowCallData(
-      attacker,
-      BOB_PK,
-      amount,
-      borrowAmount,
-      address(connextRouter),
-      address(vault),
-      slippageThreshold
+      attacker, BOB_PK, amount, borrowAmount, address(connextRouter), address(vault)
     );
 
     vm.startPrank(attacker);
@@ -256,13 +222,9 @@ contract ConnextRouterForkingTest is Routines, ForkingSetup {
     uint256 amount = 2 ether;
     uint256 borrowAmount = 1000e6;
 
-    // The maximum slippage acceptable, in BPS, due to the Connext bridging mechanics
-    // Eg. 0.05% slippage threshold will be 5.
-    uint256 slippageThreshold = 5;
-
     // make the callData to fail
     bytes memory callData = _getDepositAndBorrowCallData(
-      ALICE, ALICE_PK, amount, borrowAmount, address(0), address(vault), slippageThreshold
+      ALICE, ALICE_PK, amount, borrowAmount, address(0), address(vault)
     );
 
     // send directly the bridged funds to our router


### PR DESCRIPTION
This PR addresses M-7 and M-8 of Macro audit.