### PR TITLE
Vault validate previous providers

### DIFF
--- a/packages/protocol/src/abstracts/BaseVault.sol
+++ b/packages/protocol/src/abstracts/BaseVault.sol
@@ -943,6 +943,7 @@ abstract contract BaseVault is ERC20, SystemAccessControl, PausableVault, VaultP
     for (uint256 i = 0; i < len;) {
       if (provider == address(_providers[i])) {
         check = true;
+        break;
       }
       unchecked {
         ++i;

--- a/packages/protocol/src/abstracts/BaseVault.sol
+++ b/packages/protocol/src/abstracts/BaseVault.sol
@@ -841,14 +841,28 @@ abstract contract BaseVault is ERC20, SystemAccessControl, PausableVault, VaultP
     bytes memory callData = abi.encodeWithSignature(
       string(abi.encodePacked(method, "(address,address)")), address(this), address(this)
     );
-    bytes memory returnedBytes;
     for (uint256 i = 0; i < len;) {
-      returnedBytes = address(_providers[i]).functionStaticCall(callData, ": balance call failed");
-      assets += uint256(bytes32(returnedBytes));
+      assets += _getProviderBalanceStaticCall(_providers[i], callData);
       unchecked {
         ++i;
       }
     }
+  }
+
+  /**
+   * TODO
+   */
+  function _getProviderBalanceStaticCall(
+    ILendingProvider provider,
+    bytes memory callData
+  )
+    internal
+    view
+    returns (uint256 bal)
+  {
+    bytes memory returnedBytes =
+      address(provider).functionStaticCall(callData, ": balance call failed");
+    return uint256(bytes32(returnedBytes));
   }
 
   /*////////////////////


### PR DESCRIPTION
This draft pull request attempts to address issue in #560; however, the introduced code makes the BorrowingVault exceed the 24.4 kB limit. 
