### PR TITLE
Handle 0 fees and slippage on cross tx

### DIFF
--- a/packages/frontend/components/Borrow/Fees.tsx
+++ b/packages/frontend/components/Borrow/Fees.tsx
@@ -1,3 +1,4 @@
+import ErrorOutlineIcon from '@mui/icons-material/ErrorOutline';
 import KeyboardArrowDownIcon from '@mui/icons-material/KeyboardArrowDown';
 import KeyboardArrowUpIcon from '@mui/icons-material/KeyboardArrowUp';
 import {
@@ -15,6 +16,14 @@ import { ReactNode, useState } from 'react';
 import { FetchStatus } from '../../helpers/assets';
 import { stringifiedBridgeFeeSum } from '../../helpers/transactions';
 import { useBorrow } from '../../store/borrow.store';
+
+function ErrorComponent() {
+  return (
+    <Tooltip title="Error loading data" arrow>
+      <ErrorOutlineIcon />
+    </Tooltip>
+  );
+}
 
 function Fees() {
   const transactionMeta = useBorrow((state) => state.transactionMeta);
@@ -81,11 +90,15 @@ function Fees() {
       </Stack>
 
       <Collapse in={show} sx={{ width: '100%' }}>
-        {crossChainTx && transactionMeta.bridgeFees && (
+        {crossChainTx && (
           <Fee
             label="Bridge Fee"
             value={`~$${stringifiedBridgeFeeSum(transactionMeta.bridgeFees)}`}
             tooltip={bridgeTooltip()}
+            error={
+              !transactionMeta.bridgeFees ||
+              transactionMeta.bridgeFees?.every((fee) => fee.amount === 0)
+            }
           />
         )}
         {crossChainTx && (
@@ -99,6 +112,7 @@ function Fees() {
           <Fee
             label="Est. slippage"
             value={`~${transactionMeta.estimateSlippage} %`}
+            error={!transactionMeta.estimateSlippage}
           />
         )}
       </Collapse>
@@ -111,13 +125,16 @@ export default Fees;
 type FeeProps = {
   label: string;
   value: string | ReactNode;
-  sponsored: boolean;
+  sponsored?: boolean;
   tooltip?: string;
+  error?: boolean;
 };
 
-const Fee = ({ label, value, sponsored, tooltip }: FeeProps) => {
+const Fee = ({ label, value, sponsored, tooltip, error }: FeeProps) => {
   const { palette } = useTheme();
-  const valueComponent = sponsored ? (
+  const valueComponent = error ? (
+    <ErrorComponent />
+  ) : sponsored ? (
     <Stack
       direction="row"
       alignItems="center"

--- a/packages/sdk/src/Sdk.ts
+++ b/packages/sdk/src/Sdk.ts
@@ -99,7 +99,7 @@ export class Sdk {
     let list: Currency[] = COLLATERAL_LIST[chainId].map((token: Token) =>
       token.setConnection(this._configParams)
     );
-    // we don't support yet WMATIC and WXDAI as collateral
+    // we don't support WMATIC and WXDAI as collateral yet
     if (![ChainId.MATIC, ChainId.GNOSIS].includes(chainId)) {
       list = [NATIVE[chainId].setConnection(this._configParams), ...list];
     }
@@ -206,7 +206,7 @@ export class Sdk {
   }
 
   /**
-   * Retruns all vaults.
+   * Returns all vaults.
    *
    * @param chainType - for type of chains: mainnet or testnet
    *
@@ -227,7 +227,7 @@ export class Sdk {
   }
 
   /**
-   * Retruns all vaults with financial data such as base deposit APRs and
+   * Returns all vaults with financial data such as base deposit APRs and
    * base borrow APRs fetched on-chain.
    *
    * @remarks
@@ -252,7 +252,7 @@ export class Sdk {
   }
 
   /**
-   * Retruns all vaults with the whole financial data
+   * Returns all vaults with the whole financial data
    * loaded from DefiLlama API.
    *
    * @remarks
@@ -297,7 +297,7 @@ export class Sdk {
   }
 
   /**
-   * Retruns all vaults for a given combination of tokens and sets a connection for each of them.
+   * Returns all vaults for a given combination of tokens and sets a connection for each of them.
    *
    * @remarks
    * The vaults are sorted after checks of the lowest borrow rate for the debt token.


### PR DESCRIPTION
Did not changed sdk behaviour because catching and formatting data on FE seems like bad idea. We already have needed conditions (crosschain and 0 data)