### PR TITLE
Deployment fixes borrowing vault and factory

### DIFF
--- a/packages/protocol/src/vaults/borrowing/BorrowingVault.sol
+++ b/packages/protocol/src/vaults/borrowing/BorrowingVault.sol
@@ -693,7 +693,6 @@ contract BorrowingVault is BaseVault {
     uint256 shares
   )
     private
-    view
     returns (uint256, uint256)
   {
     if (debt == 0 || shares == 0 || owner == address(0)) {
@@ -701,7 +700,10 @@ contract BorrowingVault is BaseVault {
     }
     if (shares > _debtShares[owner]) {
       shares = _debtShares[owner];
+      uint256 debt_ = debt;
       debt = convertToDebt(shares);
+      uint256 remainder = debt_ > debt ? debt_ - debt : 0;
+      if (remainder > 0) _debtAsset.safeTransfer(owner, remainder);
     }
     return (shares, debt);
   }

--- a/packages/protocol/src/vaults/borrowing/BorrowingVault.sol
+++ b/packages/protocol/src/vaults/borrowing/BorrowingVault.sol
@@ -397,7 +397,7 @@ contract BorrowingVault is BaseVault {
   function payback(uint256 debt, address owner) public override returns (uint256) {
     uint256 shares = previewPayback(debt);
 
-    shares = _paybackChecks(owner, debt, shares);
+    (shares, debt) = _paybackChecks(owner, debt, shares);
     _payback(msg.sender, owner, debt, shares);
 
     return shares;
@@ -425,7 +425,7 @@ contract BorrowingVault is BaseVault {
   function burnDebt(uint256 shares, address owner) public override returns (uint256) {
     uint256 debt = previewBurnDebt(shares);
 
-    shares = _paybackChecks(owner, debt, shares);
+    (shares, debt) = _paybackChecks(owner, debt, shares);
     _payback(msg.sender, owner, debt, shares);
 
     return debt;
@@ -694,15 +694,16 @@ contract BorrowingVault is BaseVault {
   )
     private
     view
-    returns (uint256)
+    returns (uint256, uint256)
   {
     if (debt == 0 || shares == 0 || owner == address(0)) {
       revert BorrowingVault__payback_invalidInput();
     }
     if (shares > _debtShares[owner]) {
       shares = _debtShares[owner];
+      debt = convertToDebt(shares);
     }
-    return shares;
+    return (shares, debt);
   }
 
   /**

--- a/packages/protocol/src/vaults/borrowing/BorrowingVault.sol
+++ b/packages/protocol/src/vaults/borrowing/BorrowingVault.sol
@@ -397,8 +397,15 @@ contract BorrowingVault is BaseVault {
   function payback(uint256 debt, address owner) public override returns (uint256) {
     uint256 shares = previewPayback(debt);
 
-    (shares, debt) = _paybackChecks(owner, debt, shares);
+    uint256 remainder;
+    // `shares` and `debt` are updated if passing more than max amount for `owner`'s debt.
+    (shares, debt, remainder) = _paybackChecks(owner, debt, shares);
     _payback(msg.sender, owner, debt, shares);
+
+    if (remainder > 0) {
+      _debtAsset.safeTransferFrom(msg.sender, address(this), remainder);
+      _debtAsset.safeTransfer(owner, remainder);
+    }
 
     return shares;
   }
@@ -425,8 +432,15 @@ contract BorrowingVault is BaseVault {
   function burnDebt(uint256 shares, address owner) public override returns (uint256) {
     uint256 debt = previewBurnDebt(shares);
 
-    (shares, debt) = _paybackChecks(owner, debt, shares);
+    uint256 remainder;
+    // `shares` and `debt` are updated if passing more than max amount for `owner`'s debt.
+    (shares, debt, remainder) = _paybackChecks(owner, debt, shares);
     _payback(msg.sender, owner, debt, shares);
+
+    if (remainder > 0) {
+      _debtAsset.safeTransferFrom(msg.sender, address(this), remainder);
+      _debtAsset.safeTransfer(owner, remainder);
+    }
 
     return debt;
   }
@@ -679,7 +693,8 @@ contract BorrowingVault is BaseVault {
 
   /**
    * @dev Runs common checks for all "payback" or "burnDebt" actions in this vault and returns maximum
-   * shares to payback if exceeding `owner` debtShares balance.
+   * shares, and debt to payback if exceeding `owner` debtShares balance. It also returns excess amount to
+   * be reimbursed to `owner`.
    * Requirements:
    * - Must revert for all conditions not passed.
    *
@@ -693,19 +708,21 @@ contract BorrowingVault is BaseVault {
     uint256 shares
   )
     private
-    returns (uint256, uint256)
+    view
+    returns (uint256, uint256, uint256)
   {
     if (debt == 0 || shares == 0 || owner == address(0)) {
       revert BorrowingVault__payback_invalidInput();
     }
+
+    uint256 remainder;
     if (shares > _debtShares[owner]) {
       shares = _debtShares[owner];
       uint256 debt_ = debt;
       debt = convertToDebt(shares);
-      uint256 remainder = debt_ > debt ? debt_ - debt : 0;
-      if (remainder > 0) _debtAsset.safeTransfer(owner, remainder);
+      remainder = debt_ > debt ? debt_ - debt : 0;
     }
-    return (shares, debt);
+    return (shares, debt, remainder);
   }
 
   /**

--- a/packages/protocol/src/vaults/borrowing/BorrowingVaultBeaconFactory.sol
+++ b/packages/protocol/src/vaults/borrowing/BorrowingVaultBeaconFactory.sol
@@ -14,6 +14,7 @@ pragma solidity 0.8.15;
 import {IERC20Metadata} from
   "openzeppelin-contracts/contracts/token/ERC20/extensions/IERC20Metadata.sol";
 import {Address} from "openzeppelin-contracts/contracts/utils/Address.sol";
+import {Strings} from "openzeppelin-contracts/contracts/utils/Strings.sol";
 import {IERC20, SafeERC20} from "openzeppelin-contracts/contracts/token/ERC20/utils/SafeERC20.sol";
 import {VaultBeaconProxy} from "../VaultBeaconProxy.sol";
 import {IBeacon} from "openzeppelin-contracts/contracts/proxy/beacon/IBeacon.sol";
@@ -26,6 +27,7 @@ import {IChief} from "../../interfaces/IChief.sol";
 
 contract BorrowingVaultBeaconFactory is IBeacon, VaultDeployer {
   using SafeERC20 for IERC20;
+  using Strings for uint256;
 
   struct BVaultData {
     address asset;
@@ -123,10 +125,12 @@ contract BorrowingVaultBeaconFactory is IBeacon, VaultDeployer {
 
       // Example of `name_`: "Fuji-V2 WETH-DAI BorrowingVault-1".
       vdata.name = string(
-        abi.encodePacked("Fuji-V2 ", assetSymbol, "-", debtSymbol, " BorrowingVault", "-", nonce)
+        abi.encodePacked(
+          "Fuji-V2 ", assetSymbol, "-", debtSymbol, " BorrowingVault", "-", nonce.toString()
+        )
       );
       // Example of `symbol_`: "fbvWETHDAI-1".
-      vdata.symbol = string(abi.encodePacked("fbv", assetSymbol, debtSymbol, "-", nonce));
+      vdata.symbol = string(abi.encodePacked("fbv", assetSymbol, debtSymbol, "-", nonce.toString()));
 
       vdata.salt = keccak256(abi.encode(deployData, nonce, block.number));
 

--- a/packages/protocol/src/vaults/borrowing/BorrowingVaultUpgradeable.sol
+++ b/packages/protocol/src/vaults/borrowing/BorrowingVaultUpgradeable.sol
@@ -579,7 +579,6 @@ contract BorrowingVaultUpgradeable is BaseVaultUpgradeable {
     uint256 shares
   )
     private
-    view
     returns (uint256, uint256)
   {
     if (debt == 0 || shares == 0 || owner == address(0)) {
@@ -587,7 +586,10 @@ contract BorrowingVaultUpgradeable is BaseVaultUpgradeable {
     }
     if (shares > _debtShares[owner]) {
       shares = _debtShares[owner];
+      uint256 debt_ = debt;
       debt = convertToDebt(shares);
+      uint256 remainder = debt_ > debt ? debt_ - debt : 0;
+      if (remainder > 0) _debtAsset.safeTransfer(owner, remainder);
     }
     return (shares, debt);
   }

--- a/packages/protocol/src/vaults/borrowing/BorrowingVaultUpgradeable.sol
+++ b/packages/protocol/src/vaults/borrowing/BorrowingVaultUpgradeable.sol
@@ -302,7 +302,7 @@ contract BorrowingVaultUpgradeable is BaseVaultUpgradeable {
   function payback(uint256 debt, address owner) public override returns (uint256) {
     uint256 shares = previewPayback(debt);
 
-    shares = _paybackChecks(owner, debt, shares);
+    (shares, debt) = _paybackChecks(owner, debt, shares);
     _payback(msg.sender, owner, debt, shares);
 
     return shares;
@@ -312,7 +312,7 @@ contract BorrowingVaultUpgradeable is BaseVaultUpgradeable {
   function burnDebt(uint256 shares, address owner) public override returns (uint256) {
     uint256 debt = previewBurnDebt(shares);
 
-    shares = _paybackChecks(owner, debt, shares);
+    (shares, debt) = _paybackChecks(owner, debt, shares);
     _payback(msg.sender, owner, debt, shares);
 
     return debt;
@@ -580,15 +580,16 @@ contract BorrowingVaultUpgradeable is BaseVaultUpgradeable {
   )
     private
     view
-    returns (uint256)
+    returns (uint256, uint256)
   {
     if (debt == 0 || shares == 0 || owner == address(0)) {
       revert BorrowingVault__payback_invalidInput();
     }
     if (shares > _debtShares[owner]) {
       shares = _debtShares[owner];
+      debt = convertToDebt(shares);
     }
-    return shares;
+    return (shares, debt);
   }
 
   /**


### PR DESCRIPTION
I identified in the following [tx](https://optimistic.etherscan.io/tx/0xb02949c668f17bc8a3984aec206d51615420e5ccc47923229997e40b07be9684) that paying more than max leaves unattended assets in the vault. 

Therefore the fix is required.  This is an extension of what we discussed that must be considered in the `withdraw` if we want to have the same default to max behavior. 