### PR TITLE
Rebalancer manager max rebalance

### DIFF
--- a/packages/protocol/src/RebalancerManager.sol
+++ b/packages/protocol/src/RebalancerManager.sol
@@ -65,9 +65,6 @@ contract RebalancerManager is IRebalancerManager, SystemAccessControl {
     if (assets == type(uint256).max) {
       assets = from.getDepositBalance(address(vault), vault);
     }
-    if (debt == type(uint256).max) {
-      debt = from.getBorrowBalance(address(vault), vault);
-    }
 
     _checkAssetsAmount(vault, assets, from);
 
@@ -79,6 +76,10 @@ contract RebalancerManager is IRebalancerManager, SystemAccessControl {
       }
       vault.rebalance(assets, 0, from, to, 0, setToAsActiveProvider);
     } else {
+      if (debt == type(uint256).max) {
+        debt = from.getBorrowBalance(address(vault), vault);
+      }
+
       // BorrowingVault
       if (assets == 0 && debt == 0) {
         // Should at least move some assets or debt across providers.

--- a/packages/protocol/src/RebalancerManager.sol
+++ b/packages/protocol/src/RebalancerManager.sol
@@ -62,6 +62,13 @@ contract RebalancerManager is IRebalancerManager, SystemAccessControl {
       revert RebalancerManager__rebalanceVault_notValidExecutor();
     }
 
+    if (assets == type(uint256).max) {
+      assets = from.getDepositBalance(address(vault), vault);
+    }
+    if (debt == type(uint256).max) {
+      debt = from.getBorrowBalance(address(vault), vault);
+    }
+
     _checkAssetsAmount(vault, assets, from);
 
     if (vault.debtAsset() == address(0)) {

--- a/packages/protocol/src/interfaces/IRebalancerManager.sol
+++ b/packages/protocol/src/interfaces/IRebalancerManager.sol
@@ -36,6 +36,12 @@ interface IRebalancerManager {
    * @dev Requirements:
    * - Must only be called by a valid executor.
    * - Must check `assets` and `debt` amounts are less than `vault`'s managed amounts.
+   *
+   * NOTE: For arguments `assets` and `debt` you can pass `type(uint256).max` in solidity
+   * to effectively rebalance 100% of both assets and debt from a provider to another.
+   * Hints:
+   *  - In ethers.js use `ethers.constants.MaxUint256` to return equivalent BigNumber.
+   *  - In Foundry using console use $(cast max-uint).
    */
   function rebalanceVault(
     IVault vault,

--- a/packages/protocol/test/mocking/vaults/VaultRebalancing.t.sol
+++ b/packages/protocol/test/mocking/vaults/VaultRebalancing.t.sol
@@ -315,6 +315,23 @@ contract VaultRebalancingUnitTests is MockingSetup, MockRoutines {
     assertEq(mockProviderB.getBorrowBalance(address(bvault), IVault(address(bvault))), debt75);
   }
 
+  function test_rebalancerManagerUsingMax() public {
+    rebalancer.rebalanceVault(
+      bvault, type(uint256).max, type(uint256).max, mockProviderA, mockProviderB, flasher, true
+    );
+
+    assertEq(mockProviderA.getDepositBalance(address(bvault), IVault(address(bvault))), 0);
+    assertEq(mockProviderA.getBorrowBalance(address(bvault), IVault(address(bvault))), 0);
+
+    assertEq(
+      mockProviderB.getDepositBalance(address(bvault), IVault(address(bvault))),
+      4 * DEPOSIT_AMOUNT + bvault.convertToAssets(initVaultShares)
+    );
+    assertEq(
+      mockProviderB.getBorrowBalance(address(bvault), IVault(address(bvault))), 4 * BORROW_AMOUNT
+    );
+  }
+
   //TODO add more test cases with RebalancerManager contract.
   function test_rebalanceBorrowingVaultWithRebalancer() public {
     uint256 assets = 4 * DEPOSIT_AMOUNT + initVaultShares; // ALICE, BOB, CHARLIE, DAVID

--- a/packages/protocol/test/mocking/vaults/VaultRebalancing.t.sol
+++ b/packages/protocol/test/mocking/vaults/VaultRebalancing.t.sol
@@ -392,7 +392,7 @@ contract VaultRebalancingUnitTests is MockingSetup, MockRoutines {
   // error RebalancerManager__checkAssetsAmount_invalidAmount();
   function test_checkAssetsAmountInvalidAmount(uint256 invalidAmount) public {
     uint256 assets = 4 * DEPOSIT_AMOUNT + initVaultShares; // ALICE, BOB, CHARLIE, DAVID
-    vm.assume(invalidAmount > assets);
+    vm.assume(invalidAmount > assets && invalidAmount != type(uint256).max);
 
     //rebalance with more amount than available should revert
     vm.expectRevert(RebalancerManager.RebalancerManager__checkAssetsAmount_invalidAmount.selector);
@@ -404,7 +404,7 @@ contract VaultRebalancingUnitTests is MockingSetup, MockRoutines {
   function test_checkDebtAmountInvalidAmount(uint256 invalidAmount) public {
     uint256 assets = 4 * DEPOSIT_AMOUNT; // ALICE, BOB, CHARLIE, DAVID
     uint256 debt = mockProviderA.getBorrowBalance(address(bvault), IVault(address(bvault)));
-    vm.assume(invalidAmount > debt); //ALICE, BOB, CHARLIE, DAVID
+    vm.assume(invalidAmount > debt && invalidAmount != type(uint256).max); //ALICE, BOB, CHARLIE, DAVID
 
     // Rebalance with more amount than available should revert
     vm.expectRevert(RebalancerManager.RebalancerManager__checkDebtAmount_invalidAmount.selector);


### PR DESCRIPTION
This pull request adds logic to the RebalancerManager.sol contract, in order to pass `type(uint).max` argument for assets and debt, to easily move entire position from one provider to another. 