### PR TITLE
Precision of max payback withdraw

### DIFF
--- a/packages/protocol/src/abstracts/BaseVault.sol
+++ b/packages/protocol/src/abstracts/BaseVault.sol
@@ -626,17 +626,14 @@ abstract contract BaseVault is ERC20, SystemAccessControl, PausableVault, VaultP
     if (receiver == address(0) || owner == address(0) || assets == 0 || shares == 0) {
       revert BaseVault__withdraw_invalidInput();
     }
-    // This local var helps save gas not having to call provider balances again.
-    // and it is multiplied by asset decimals to mantain precision.
-    uint256 sharesExchangeRatio = assets.mulDiv(10 ** (decimals()), shares);
 
     uint256 maxWithdraw_ = maxWithdraw(owner);
     if (assets > maxWithdraw_) {
+      shares_ = balanceOf(owner);
       assets_ = maxWithdraw_;
-      shares_ = assets_.mulDiv(10 ** (decimals()), sharesExchangeRatio);
     } else {
       assets_ = assets;
-      shares_ = assets_.mulDiv(10 ** (decimals()), sharesExchangeRatio);
+      shares_ = shares;
     }
     if (caller != owner) {
       _spendWithdrawAllowance(owner, caller, receiver, assets_);

--- a/packages/protocol/src/abstracts/BaseVault.sol
+++ b/packages/protocol/src/abstracts/BaseVault.sol
@@ -629,8 +629,8 @@ abstract contract BaseVault is ERC20, SystemAccessControl, PausableVault, VaultP
 
     uint256 maxWithdraw_ = maxWithdraw(owner);
     if (assets > maxWithdraw_) {
-      shares_ = balanceOf(owner);
       assets_ = maxWithdraw_;
+      shares_ = assets_.mulDiv(shares, assets);
     } else {
       assets_ = assets;
       shares_ = shares;

--- a/packages/protocol/src/abstracts/BaseVaultUpgradeable.sol
+++ b/packages/protocol/src/abstracts/BaseVaultUpgradeable.sol
@@ -512,8 +512,8 @@ abstract contract BaseVaultUpgradeable is
 
     uint256 maxWithdraw_ = maxWithdraw(owner);
     if (assets > maxWithdraw_) {
-      shares_ = balanceOf(owner);
       assets_ = maxWithdraw_;
+      shares_ = assets_.mulDiv(shares, assets);
     } else {
       assets_ = assets;
       shares_ = shares;

--- a/packages/protocol/src/abstracts/BaseVaultUpgradeable.sol
+++ b/packages/protocol/src/abstracts/BaseVaultUpgradeable.sol
@@ -509,17 +509,14 @@ abstract contract BaseVaultUpgradeable is
     if (receiver == address(0) || owner == address(0) || assets == 0 || shares == 0) {
       revert BaseVault__withdraw_invalidInput();
     }
-    // This local var helps save gas not having to call provider balances again.
-    // and it is multiplied by asset decimals to mantain precision.
-    uint256 sharesExchangeRatio = assets.mulDiv(10 ** (decimals()), shares);
 
     uint256 maxWithdraw_ = maxWithdraw(owner);
     if (assets > maxWithdraw_) {
+      shares_ = balanceOf(owner);
       assets_ = maxWithdraw_;
-      shares_ = assets_.mulDiv(10 ** (decimals()), sharesExchangeRatio);
     } else {
       assets_ = assets;
-      shares_ = assets_.mulDiv(10 ** (decimals()), sharesExchangeRatio);
+      shares_ = shares;
     }
     if (caller != owner) {
       _spendWithdrawAllowance(owner, caller, receiver, assets_);

--- a/packages/protocol/src/vaults/borrowing/BorrowingVault.sol
+++ b/packages/protocol/src/vaults/borrowing/BorrowingVault.sol
@@ -727,17 +727,14 @@ contract BorrowingVault is BaseVault {
     if (owner == address(0) || debt == 0 || shares == 0) {
       revert BorrowingVault__payback_invalidInput();
     }
-    // This local var helps save gas not having to call provider balances again
-    // and is multiplied by debtAsset decimals to mantain precision.
-    uint256 sharesExchangeRatio = debt.mulDiv(10 ** _debtDecimals, shares);
 
     if (shares > _debtShares[owner]) {
       shares_ = _debtShares[owner];
-      debt_ = shares_.mulDiv(sharesExchangeRatio, 10 ** _debtDecimals);
+      debt_ = shares_.mulDiv(debt, shares, Math.Rounding.Up);
       remainder = debt > debt_ ? debt - debt_ : 0;
     } else {
       shares_ = shares;
-      debt_ = shares_.mulDiv(sharesExchangeRatio, 10 ** _debtDecimals);
+      debt_ = debt;
     }
   }
 

--- a/packages/protocol/src/vaults/borrowing/BorrowingVaultUpgradeable.sol
+++ b/packages/protocol/src/vaults/borrowing/BorrowingVaultUpgradeable.sol
@@ -613,17 +613,14 @@ contract BorrowingVaultUpgradeable is BaseVaultUpgradeable {
     if (owner == address(0) || debt == 0 || shares == 0) {
       revert BorrowingVault__payback_invalidInput();
     }
-    // This local var helps save gas not having to call provider balances again
-    // and is multiplied by debtAsset decimals to mantain precision.
-    uint256 shareExchangeRatio = debt.mulDiv(10 ** _debtDecimals, shares);
 
     if (shares > _debtShares[owner]) {
       shares_ = _debtShares[owner];
-      debt_ = shares_.mulDiv(shareExchangeRatio, 10 ** _debtDecimals);
+      debt_ = shares_.mulDiv(debt, shares, Math.Rounding.Up);
       remainder = debt > debt_ ? debt - debt_ : 0;
     } else {
       shares_ = shares;
-      debt_ = shares_.mulDiv(shareExchangeRatio, 10 ** _debtDecimals);
+      debt_ = debt;
     }
   }
 

--- a/packages/protocol/test/PrecisionMath.t.sol
+++ b/packages/protocol/test/PrecisionMath.t.sol
@@ -1,0 +1,152 @@
+// SPDX-License-Identifier: UNLICENSED
+pragma solidity 0.8.15;
+
+import {Test} from "forge-std/Test.sol";
+import {console} from "forge-std/console.sol";
+import {MathUpgradeable as Math} from
+  "openzeppelin-contracts-upgradeable/contracts/utils/math/MathUpgradeable.sol";
+
+uint256 constant ERROR_LIMIT = 1e3;
+
+contract MathPrecision {
+  using Math for uint256;
+
+  error excessError(uint256);
+
+  uint256 internal constant PRECISION = 1e27;
+
+  function checkExchangeRatioNotZero(uint256 numa, uint256 shares) public pure returns (bool) {
+    return numa.mulDiv(PRECISION, shares) > 0;
+  }
+
+  function checkConversionAndRemainder(
+    uint256 numa,
+    uint256 shares,
+    uint256 shareLimit
+  )
+    public
+    view
+    returns (uint256 numa_, uint256 shares_, uint256 remainder)
+  {
+    if (shares > shareLimit) {
+      shares_ = shareLimit;
+      numa_ = shares_.mulDiv(numa, shares);
+      remainder = numa - numa_;
+      console.log("numa_", numa_, "remainder", remainder);
+    } else {
+      shares_ = shares;
+      numa_ = numa;
+      console.log("numa_", numa_, "remainder", remainder);
+    }
+  }
+
+  function getAmountFromExchangeRatio(
+    uint256 numa,
+    uint256 shares,
+    uint256 otherShareAmount
+  )
+    public
+    view
+    returns (uint256)
+  {
+    uint256 exchangeRatio = numa.mulDiv(PRECISION, shares);
+    console.log("exchangeRatio", exchangeRatio);
+    return otherShareAmount.mulDiv(exchangeRatio, PRECISION);
+  }
+
+  function checkUnchangedEquivalence(
+    uint256 numa,
+    uint256 shares
+  )
+    public
+    view
+    returns (uint256 numa_, uint256 shares_)
+  {
+    uint256 e;
+
+    shares_ = numa.mulDiv(shares, numa);
+    console.log("shares_-shares", shares_, shares);
+    (shares_, e) = fixPrecisionDiff(shares, shares_);
+
+    numa_ = shares.mulDiv(numa, shares);
+    console.log("numa_-numa", numa_, numa);
+    (numa_, e) = fixPrecisionDiff(numa, numa_);
+  }
+
+  function fixPrecisionDiff(
+    uint256 original,
+    uint256 computed
+  )
+    public
+    pure
+    returns (uint256 fix, uint256 e)
+  {
+    e = computed >= original ? computed - original : original - computed;
+    if (e > 0 && e < ERROR_LIMIT + 1) {
+      fix = computed - e == original ? computed - e : computed + e;
+    } else if (e == 0) {
+      fix = computed;
+    } else {
+      revert excessError(e);
+    }
+  }
+}
+
+contract MathPrecisionTest is Test {
+  using Math for uint256;
+  using Math for uint128;
+
+  MathPrecision public mathPrecision;
+
+  function setUp() public {
+    mathPrecision = new MathPrecision();
+  }
+
+  function test_mathPrecisionUnchangedEquivalenceFuzz(uint128 numA, uint128 sharesA) public {
+    // uint128 numA = 998567;
+    // uint128 sharesA = 1996792;
+    vm.assume(numA > 0 && sharesA > 0 && mathPrecision.checkExchangeRatioNotZero(numA, sharesA));
+    (uint256 computedA, uint256 computedSharesA) =
+      mathPrecision.checkUnchangedEquivalence(numA, sharesA);
+    assertEq(computedA, numA);
+    assertEq(computedSharesA, sharesA);
+  }
+
+  function test_mathPrecisionCheckConversionAndRemainderFuzz(
+    uint128 numA,
+    uint128 sharesA,
+    uint128 shareLimit
+  )
+    public
+  {
+    // uint128 numA = 998567;
+    // uint128 sharesA = 1996792;
+    // uint128 shareLimit = 1996700;
+    vm.assume(numA > 0 && sharesA > 0 && mathPrecision.checkExchangeRatioNotZero(numA, sharesA));
+    (uint256 computedA, uint256 computedSharesA, uint256 remainder) =
+      mathPrecision.checkConversionAndRemainder(numA, sharesA, shareLimit);
+
+    if (shareLimit < sharesA) {
+      assertEq(computedSharesA, shareLimit);
+      assertLt(computedA, numA);
+      assertEq(remainder, numA - computedA);
+
+      /*
+      // For reference only to check
+      uint256 fromExchangeRatio =
+        mathPrecision.getAmountFromExchangeRatio(numA, sharesA, shareLimit);
+      console.log("comparison-fromExchangeRatio-normal", fromExchangeRatio, computedA);
+      */
+
+      uint256 expectedResult = numA.mulDiv(shareLimit, sharesA);
+
+      uint256 errorDiff =
+        computedA > expectedResult ? computedA - expectedResult : expectedResult - computedA;
+      assertLt(errorDiff, ERROR_LIMIT + 1);
+    } else {
+      assertEq(computedA, numA);
+      assertEq(computedSharesA, sharesA);
+      assertEq(remainder, 0);
+    }
+  }
+}

--- a/packages/protocol/test/forking/ForkingSetup2.sol
+++ b/packages/protocol/test/forking/ForkingSetup2.sol
@@ -87,6 +87,8 @@ contract ForkingSetup2 is CoreRoles, Test {
   BorrowingVaultBeaconFactory factory;
   address implementation;
 
+  address connextCore;
+
   uint256 public constant DEFAULT_MAX_LTV = 75e16; // 75%
   uint256 public constant DEFAULT_LIQ_RATIO = 82.5e16; // 82.5%
 
@@ -121,10 +123,10 @@ contract ForkingSetup2 is CoreRoles, Test {
 
   function setOrDeployConnextRouter(bool deploy) internal {
     if (deploy) {
-      address connext = readAddrFromConfig("ConnextCore");
+      connextCore = readAddrFromConfig("ConnextCore");
       address weth = readAddrFromConfig("WETH");
 
-      connextRouter = new ConnextRouter(IWETH9(weth), IConnext(connext), Chief(chief));
+      connextRouter = new ConnextRouter(IWETH9(weth), IConnext(connextCore), Chief(chief));
     } else {
       connextRouter = ConnextRouter(payable(getAddress("ConnextRouter")));
     }

--- a/packages/protocol/test/forking/goerli/ConnextRouterVaultIntegration.t.sol
+++ b/packages/protocol/test/forking/goerli/ConnextRouterVaultIntegration.t.sol
@@ -7,7 +7,11 @@ import {Routines} from "../../utils/Routines.sol";
 import {BorrowingVaultUpgradeable as BVault} from
   "../../../src/vaults/borrowing/BorrowingVaultUpgradeable.sol";
 import {IVault} from "../../../src/interfaces/IVault.sol";
-import {AaveV3Goerli as SampleProvider} from "../../../src/providers/goerli/AaveV3Goerli.sol";
+import {
+  ILendingProvider,
+  IV3Pool,
+  AaveV3Goerli as SampleProvider
+} from "../../../src/providers/goerli/AaveV3Goerli.sol";
 import {
   ConnextRouter, ConnextHandler, XReceiveProxy
 } from "../../../src/routers/ConnextRouter.sol";
@@ -18,6 +22,8 @@ import {Math} from "openzeppelin-contracts/contracts/utils/math/Math.sol";
 bool constant DEBUG = true;
 
 contract ConnextRouterVaultIntegrations is Routines, ForkingSetup2 {
+  error xReceiveFailed_recordedTransfer();
+
   using Math for uint256;
 
   BVault public vault;
@@ -29,7 +35,7 @@ contract ConnextRouterVaultIntegrations is Routines, ForkingSetup2 {
   XReceiveProxy public xReceiveProxy;
 
   uint256 internal constant DEPOSIT_AMOUNT = 0.25 ether;
-  uint256 internal constant BORROW_AMOUNT = 2e6;
+  uint256 internal constant BORROW_AMOUNT = 998567;
 
   address collateralAsset;
   address debtAsset;
@@ -101,13 +107,21 @@ contract ConnextRouterVaultIntegrations is Routines, ForkingSetup2 {
   }
 
   function test_attemptMaxPaybackSDKOverestimate() public {
+    __doUnbalanceDebtToSharesRatio(address(vault));
+
     // Assume ALICE already has a position in this domain.
     do_depositAndBorrow(DEPOSIT_AMOUNT, BORROW_AMOUNT, IVault(address(vault)), ALICE);
 
+    __closeBOB(address(vault));
+
     // Record Alice debt for future assertions.
     uint256 aliceDebtBefore = vault.balanceOfDebt(ALICE);
+    uint256 aliceDebtSharesBefore = vault.balanceOfDebtShares(ALICE);
     if (DEBUG) {
-      console.log("aliceDebtBefore", aliceDebtBefore);
+      console.log("Alice original debt", BORROW_AMOUNT);
+      console.log("debtShare-to-debt-ratio-alteration");
+      console.log("aliceDebtBeforeXCall", aliceDebtBefore);
+      console.log("aliceDebtSharesBeforeXCall", aliceDebtSharesBefore);
     }
 
     // From a seperate domain ALICE wants to make a max payback
@@ -125,9 +139,9 @@ contract ConnextRouterVaultIntegrations is Routines, ForkingSetup2 {
       // - [cfee] the connext 5 bps fee
       // - [slippage] potential connext slippage
       // Therefore: estimate = ira + cfee + slippage
-      feeAndSlippage = BORROW_AMOUNT.mulDiv(5, 1e4) + BORROW_AMOUNT.mulDiv(3, 1e3);
+      feeAndSlippage = aliceDebtBefore.mulDiv(5, 1e4) + aliceDebtBefore.mulDiv(3, 1e3);
       uint256 buffer = overEstimate + feeAndSlippage;
-      sdkAmount = BORROW_AMOUNT + buffer;
+      sdkAmount = aliceDebtBefore + buffer;
       args[0] = abi.encode(address(vault), sdkAmount, ALICE, address(connextRouter));
     }
 
@@ -146,9 +160,14 @@ contract ConnextRouterVaultIntegrations is Routines, ForkingSetup2 {
     // Call pretended from connextCore to xReceiveProxy from a seperate domain (eg. optimism goerli).
     // simulated to be the same address as ConnextRouter in this test.
     xReceiveProxy.xReceive(
-      "", finalReceived, debtAsset, address(connextRouter), OPTIMISM_GOERLI_DOMAIN, callData
+      "0x01", finalReceived, debtAsset, address(connextRouter), OPTIMISM_GOERLI_DOMAIN, callData
     );
     vm.stopPrank();
+
+    // Handler should have no funds
+    if (IERC20(debtAsset).balanceOf(address(connextHandler)) > 0) {
+      revert xReceiveFailed_recordedTransfer();
+    }
 
     {
       // Assert Alice's debt is now zero by the amount in cross-tx.
@@ -159,7 +178,7 @@ contract ConnextRouterVaultIntegrations is Routines, ForkingSetup2 {
       assertEq(aliceDebtAfter, 0);
       assertEq(aliceDebSharestAfter, 0);
       // Assert Alice has receive any overestimate
-      assertEq(aliceUSDCBalanceAfter, aliceDebtBefore + overEstimate);
+      assertEq(aliceUSDCBalanceAfter, BORROW_AMOUNT + overEstimate);
 
       if (DEBUG) {
         console.log("aliceDebtAfter", aliceDebtAfter, "aliceDebSharestAfter", aliceDebSharestAfter);
@@ -184,13 +203,21 @@ contract ConnextRouterVaultIntegrations is Routines, ForkingSetup2 {
   }
 
   function test_attemptMaxPaybackSDKUnderestimate() public {
+    __doUnbalanceDebtToSharesRatio(address(vault));
+
     // Assume ALICE already has a position in this domain.
     do_depositAndBorrow(DEPOSIT_AMOUNT, BORROW_AMOUNT, IVault(address(vault)), ALICE);
 
+    __closeBOB(address(vault));
+
     // Record Alice debt for future assertions.
     uint256 aliceDebtBefore = vault.balanceOfDebt(ALICE);
+    uint256 aliceDebtSharesBefore = vault.balanceOfDebtShares(ALICE);
     if (DEBUG) {
-      console.log("aliceDebtBefore", aliceDebtBefore);
+      console.log("Alice original debt", BORROW_AMOUNT);
+      console.log("debtShare-to-debt-ratio-alteration");
+      console.log("aliceDebtBeforeXCall", aliceDebtBefore);
+      console.log("aliceDebtSharesBeforeXCall", aliceDebtSharesBefore);
     }
 
     // From a seperate domain ALICE wants to make a max payback
@@ -208,8 +235,8 @@ contract ConnextRouterVaultIntegrations is Routines, ForkingSetup2 {
       // - [cfee] the connext 5 bps fee
       // - [slippage] potential connext slippage
       // Therefore: estimate = ira + cfee + slippage
-      feeAndSlippage = BORROW_AMOUNT.mulDiv(5, 1e4) + BORROW_AMOUNT.mulDiv(3, 1e3);
-      sdkAmount = BORROW_AMOUNT + feeAndSlippage - underEstimation;
+      feeAndSlippage = aliceDebtBefore.mulDiv(5, 1e4) + aliceDebtBefore.mulDiv(3, 1e3);
+      sdkAmount = aliceDebtBefore + feeAndSlippage - underEstimation;
       args[0] = abi.encode(address(vault), sdkAmount, ALICE, address(connextRouter));
     }
 
@@ -228,9 +255,14 @@ contract ConnextRouterVaultIntegrations is Routines, ForkingSetup2 {
     // Call pretended from connextCore to xReceiveProxy from a seperate domain (eg. optimism goerli).
     // simulated to be the same address as ConnextRouter in this test.
     xReceiveProxy.xReceive(
-      "", finalReceived, debtAsset, address(connextRouter), OPTIMISM_GOERLI_DOMAIN, callData
+      "0x01", finalReceived, debtAsset, address(connextRouter), OPTIMISM_GOERLI_DOMAIN, callData
     );
     vm.stopPrank();
+
+    // Handler should have no funds
+    if (IERC20(debtAsset).balanceOf(address(connextHandler)) > 0) {
+      revert xReceiveFailed_recordedTransfer();
+    }
 
     {
       // Assert Alice's debt is now zero by the amount in cross-tx.
@@ -239,9 +271,10 @@ contract ConnextRouterVaultIntegrations is Routines, ForkingSetup2 {
       uint256 aliceUSDCBalanceAfter = IERC20(debtAsset).balanceOf(ALICE);
 
       assertGt(aliceDebtAfter, 0);
+      assertGt(aliceDebtAfter, 0);
       assertGt(aliceDebSharestAfter, 0);
       // Assert Alice has NOT receive any overestimate
-      assertEq(aliceUSDCBalanceAfter, aliceDebtBefore);
+      assertEq(aliceUSDCBalanceAfter, BORROW_AMOUNT);
 
       if (DEBUG) {
         console.log("aliceDebtAfter", aliceDebtAfter, "aliceDebSharestAfter", aliceDebSharestAfter);
@@ -263,5 +296,30 @@ contract ConnextRouterVaultIntegrations is Routines, ForkingSetup2 {
         console.log("vaultDebtBalanceAtProvider", vaultDebtBalanceAtProvider);
       }
     }
+  }
+
+  function __doUnbalanceDebtToSharesRatio(address vault_) internal {
+    ILendingProvider activeProvider_ = BVault(payable(vault_)).activeProvider();
+
+    do_depositAndBorrow(DEPOSIT_AMOUNT, BORROW_AMOUNT, IVault(address(vault)), BOB);
+
+    uint256 debtBalance = activeProvider_.getBorrowBalance(vault_, IVault(vault_));
+    address debtAsset_ = IVault(vault_).debtAsset();
+
+    uint256 amountToAdjust = debtBalance / 2;
+
+    deal(debtAsset_, address(this), amountToAdjust);
+    IV3Pool aave = IV3Pool(activeProvider_.approvedOperator(address(0), address(0), address(0)));
+
+    IERC20(debtAsset_).approve(address(aave), amountToAdjust);
+    aave.repay(debtAsset_, amountToAdjust, 2, vault_);
+  }
+
+  function __closeBOB(address vault_) internal {
+    uint256 maxPayback = IVault(vault_).maxPayback(BOB);
+    address debtAsset_ = IVault(vault_).debtAsset();
+    deal(debtAsset_, address(this), maxPayback);
+    IERC20(debtAsset_).approve(vault_, maxPayback);
+    IVault(vault_).payback(maxPayback, BOB);
   }
 }

--- a/packages/protocol/test/forking/goerli/ConnextRouterVaultIntegration.t.sol
+++ b/packages/protocol/test/forking/goerli/ConnextRouterVaultIntegration.t.sol
@@ -1,0 +1,267 @@
+// SPDX-License-Identifier: UNLICENSED
+pragma solidity 0.8.15;
+
+import {console} from "forge-std/console.sol";
+import {ForkingSetup2} from "../ForkingSetup2.sol";
+import {Routines} from "../../utils/Routines.sol";
+import {BorrowingVaultUpgradeable as BVault} from
+  "../../../src/vaults/borrowing/BorrowingVaultUpgradeable.sol";
+import {IVault} from "../../../src/interfaces/IVault.sol";
+import {AaveV3Goerli as SampleProvider} from "../../../src/providers/goerli/AaveV3Goerli.sol";
+import {
+  ConnextRouter, ConnextHandler, XReceiveProxy
+} from "../../../src/routers/ConnextRouter.sol";
+import {IRouter} from "../../../src/interfaces/IRouter.sol";
+import {IERC20} from "openzeppelin-contracts/contracts/token/ERC20/IERC20.sol";
+import {Math} from "openzeppelin-contracts/contracts/utils/math/Math.sol";
+
+bool constant DEBUG = true;
+
+contract ConnextRouterVaultIntegrations is Routines, ForkingSetup2 {
+  using Math for uint256;
+
+  BVault public vault;
+  address[] public vaults;
+
+  SampleProvider sprovider;
+
+  ConnextHandler public connextHandler;
+  XReceiveProxy public xReceiveProxy;
+
+  uint256 internal constant DEPOSIT_AMOUNT = 0.25 ether;
+  uint256 internal constant BORROW_AMOUNT = 2e6;
+
+  address collateralAsset;
+  address debtAsset;
+
+  function setUp() public {
+    setUpFork("goerli");
+
+    sprovider = SampleProvider(getAddress("Aave_V3_Goerli"));
+    vm.label(address(sprovider), "SampleProvider");
+
+    vm.startPrank(msg.sender);
+    setOrDeployChief(true);
+    setOrDeployConnextRouter(true);
+    setOrDeployFujiOracle(true);
+    setOrDeployBorrowingVaultFactory(true, true);
+    vaults = deployBorrowingVaults();
+    vm.stopPrank();
+    /*setBorrowingVaults();*/
+
+    vault = BVault(payable(vaults[0]));
+
+    collateralAsset = vault.asset();
+    debtAsset = vault.debtAsset();
+
+    connextHandler = connextRouter.handler();
+    xReceiveProxy = XReceiveProxy(connextRouter.xReceiveProxy());
+
+    vm.startPrank(address(timelock));
+    // Assume the same address of xreceive in all domains.
+    connextRouter.setRouter(GOERLI_DOMAIN, address(xReceiveProxy));
+    connextRouter.setRouter(OPTIMISM_GOERLI_DOMAIN, address(xReceiveProxy));
+    connextRouter.setRouter(MUMBAI_DOMAIN, address(xReceiveProxy));
+    vm.stopPrank();
+  }
+
+  function test_basicVaultParamsInitialized() public {
+    address asset_ = vault.asset();
+    address debtAsset_ = vault.debtAsset();
+    uint256 maxltv_ = vault.maxLtv();
+    uint256 liqRatio_ = vault.liqRatio();
+    address oracle_ = address(vault.oracle());
+    address activeProvider_ = address(vault.activeProvider());
+    uint256 totalSupply_ = vault.totalSupply();
+    uint256 debtSharesSupply_ = vault.debtSharesSupply();
+
+    // console.log("asset", asset_, "debtAsset", debtAsset_);
+    // console.log("maxltv", maxltv_, "liqRatio", liqRatio_);
+    // console.log("oracle", oracle_, "activeProvider", activeProvider);
+    // console.log("totalSupply", totalSupply_, "debtSharesSupply", debtSharesSupply_);
+
+    assertNotEq(asset_, address(0));
+    assertNotEq(debtAsset_, address(0));
+    assertNotEq(oracle_, address(0));
+    assertNotEq(activeProvider_, address(0));
+    assertGt(maxltv_, 0);
+    assertGt(liqRatio_, 0);
+    assertGt(totalSupply_, 0);
+    assertEq(debtSharesSupply_, 0);
+  }
+
+  function test_basicConnextRouterInitialized() public {
+    address chief_ = address(connextRouter.chief());
+    address receiver_ = connextRouter.xReceiveProxy();
+    address handler_ = address(connextRouter.handler());
+
+    assertEq(chief_, address(chief));
+    assertEq(receiver_, address(xReceiveProxy));
+    assertEq(handler_, address(connextHandler));
+  }
+
+  function test_attemptMaxPaybackSDKOverestimate() public {
+    // Assume ALICE already has a position in this domain.
+    do_depositAndBorrow(DEPOSIT_AMOUNT, BORROW_AMOUNT, IVault(address(vault)), ALICE);
+
+    // Record Alice debt for future assertions.
+    uint256 aliceDebtBefore = vault.balanceOfDebt(ALICE);
+    if (DEBUG) {
+      console.log("aliceDebtBefore", aliceDebtBefore);
+    }
+
+    // From a seperate domain ALICE wants to make a max payback
+    // The SDK prepares the bundle for her.
+    IRouter.Action[] memory actions = new IRouter.Action[](1);
+    bytes[] memory args = new bytes[](1);
+
+    uint256 sdkAmount;
+    uint256 feeAndSlippage;
+    uint256 overEstimate = 1000 wei;
+    {
+      actions[0] = IRouter.Action.Payback;
+      // We expect the SDK to estimate a buffer amount that includes:
+      // - [ira] interest rate accrued buffer during time of xCall
+      // - [cfee] the connext 5 bps fee
+      // - [slippage] potential connext slippage
+      // Therefore: estimate = ira + cfee + slippage
+      feeAndSlippage = BORROW_AMOUNT.mulDiv(5, 1e4) + BORROW_AMOUNT.mulDiv(3, 1e3);
+      uint256 buffer = overEstimate + feeAndSlippage;
+      sdkAmount = BORROW_AMOUNT + buffer;
+      args[0] = abi.encode(address(vault), sdkAmount, ALICE, address(connextRouter));
+    }
+
+    bytes memory callData = abi.encode(actions, args);
+
+    // send directly the bridged funds to our xReceiver; thus simulating ConnextCore
+    // behaviour. However, the final received amount is resultant
+    // of deducting the Connext fee and slippage amount.
+    uint256 finalReceived;
+    {
+      finalReceived = sdkAmount - feeAndSlippage;
+      deal(debtAsset, address(xReceiveProxy), finalReceived);
+    }
+
+    vm.startPrank(connextCore);
+    // Call pretended from connextCore to xReceiveProxy from a seperate domain (eg. optimism goerli).
+    // simulated to be the same address as ConnextRouter in this test.
+    xReceiveProxy.xReceive(
+      "", finalReceived, debtAsset, address(connextRouter), OPTIMISM_GOERLI_DOMAIN, callData
+    );
+    vm.stopPrank();
+
+    {
+      // Assert Alice's debt is now zero by the amount in cross-tx.
+      uint256 aliceDebtAfter = vault.balanceOfDebt(ALICE);
+      uint256 aliceDebSharestAfter = vault.balanceOfDebtShares(ALICE);
+      uint256 aliceUSDCBalanceAfter = IERC20(debtAsset).balanceOf(ALICE);
+
+      assertEq(aliceDebtAfter, 0);
+      assertEq(aliceDebSharestAfter, 0);
+      // Assert Alice has receive any overestimate
+      assertEq(aliceUSDCBalanceAfter, aliceDebtBefore + overEstimate);
+
+      if (DEBUG) {
+        console.log("aliceDebtAfter", aliceDebtAfter, "aliceDebSharestAfter", aliceDebSharestAfter);
+        console.log("aliceUSDCBalanceAfter", aliceUSDCBalanceAfter);
+      }
+    }
+
+    {
+      // Check vault status
+      uint256 vaultDebtSharesSupply = vault.debtSharesSupply();
+      uint256 vaultDebtBalanceAtProvider =
+        sprovider.getBorrowBalance(address(vault), IVault(address(vault)));
+
+      assertEq(vaultDebtSharesSupply, 0);
+      assertEq(vaultDebtBalanceAtProvider, 0);
+
+      if (DEBUG) {
+        console.log("vaultDebtSharesSupply", vaultDebtSharesSupply);
+        console.log("vaultDebtBalanceAtProvider", vaultDebtBalanceAtProvider);
+      }
+    }
+  }
+
+  function test_attemptMaxPaybackSDKUnderestimate() public {
+    // Assume ALICE already has a position in this domain.
+    do_depositAndBorrow(DEPOSIT_AMOUNT, BORROW_AMOUNT, IVault(address(vault)), ALICE);
+
+    // Record Alice debt for future assertions.
+    uint256 aliceDebtBefore = vault.balanceOfDebt(ALICE);
+    if (DEBUG) {
+      console.log("aliceDebtBefore", aliceDebtBefore);
+    }
+
+    // From a seperate domain ALICE wants to make a max payback
+    // The SDK prepares the bundle for her.
+    IRouter.Action[] memory actions = new IRouter.Action[](1);
+    bytes[] memory args = new bytes[](1);
+
+    uint256 sdkAmount;
+    uint256 feeAndSlippage;
+    uint256 underEstimation = 99999 wei;
+    {
+      actions[0] = IRouter.Action.Payback;
+      // We expect the SDK to estimate a buffer amount that includes:
+      // - [ira] interest rate accrued buffer during time of xCall
+      // - [cfee] the connext 5 bps fee
+      // - [slippage] potential connext slippage
+      // Therefore: estimate = ira + cfee + slippage
+      feeAndSlippage = BORROW_AMOUNT.mulDiv(5, 1e4) + BORROW_AMOUNT.mulDiv(3, 1e3);
+      sdkAmount = BORROW_AMOUNT + feeAndSlippage - underEstimation;
+      args[0] = abi.encode(address(vault), sdkAmount, ALICE, address(connextRouter));
+    }
+
+    bytes memory callData = abi.encode(actions, args);
+
+    // send directly the bridged funds to our xReceiver; thus simulating ConnextCore
+    // behaviour. However, the final received amount is resultant
+    // of deducting the Connext fee and slippage amount.
+    uint256 finalReceived;
+    {
+      finalReceived = sdkAmount - feeAndSlippage;
+      deal(debtAsset, address(xReceiveProxy), finalReceived);
+    }
+
+    vm.startPrank(connextCore);
+    // Call pretended from connextCore to xReceiveProxy from a seperate domain (eg. optimism goerli).
+    // simulated to be the same address as ConnextRouter in this test.
+    xReceiveProxy.xReceive(
+      "", finalReceived, debtAsset, address(connextRouter), OPTIMISM_GOERLI_DOMAIN, callData
+    );
+    vm.stopPrank();
+
+    {
+      // Assert Alice's debt is now zero by the amount in cross-tx.
+      uint256 aliceDebtAfter = vault.balanceOfDebt(ALICE);
+      uint256 aliceDebSharestAfter = vault.balanceOfDebtShares(ALICE);
+      uint256 aliceUSDCBalanceAfter = IERC20(debtAsset).balanceOf(ALICE);
+
+      assertGt(aliceDebtAfter, 0);
+      assertGt(aliceDebSharestAfter, 0);
+      // Assert Alice has NOT receive any overestimate
+      assertEq(aliceUSDCBalanceAfter, aliceDebtBefore);
+
+      if (DEBUG) {
+        console.log("aliceDebtAfter", aliceDebtAfter, "aliceDebSharestAfter", aliceDebSharestAfter);
+        console.log("aliceUSDCBalanceAfter", aliceUSDCBalanceAfter);
+      }
+    }
+
+    {
+      // Check vault status
+      uint256 vaultDebtSharesSupply = vault.debtSharesSupply();
+      uint256 vaultDebtBalanceAtProvider =
+        sprovider.getBorrowBalance(address(vault), IVault(address(vault)));
+
+      assertGt(vaultDebtSharesSupply, 0);
+      assertGt(vaultDebtBalanceAtProvider, 0);
+
+      if (DEBUG) {
+        console.log("vaultDebtSharesSupply", vaultDebtSharesSupply);
+        console.log("vaultDebtBalanceAtProvider", vaultDebtBalanceAtProvider);
+      }
+    }
+  }
+}

--- a/packages/protocol/test/mocking/vaults/Vault.t.sol
+++ b/packages/protocol/test/mocking/vaults/Vault.t.sol
@@ -230,13 +230,19 @@ contract VaultUnitTests is MockingSetup, MockRoutines {
 
     do_depositAndBorrow(amount, borrowAmount, vault, ALICE);
 
+    uint256 aliceShares = vault.balanceOf(ALICE);
     uint256 maxWithdrawable = vault.maxWithdraw(ALICE);
+    uint256 maxRedeemable = vault.maxRedeem(ALICE);
 
     vm.prank(ALICE);
     vault.withdraw(type(uint256).max, ALICE, ALICE);
 
+    uint256 aliceSharesAfter = vault.balanceOf(ALICE);
+
     // Assert user received exactly the maxWithdrawable amount
     assertEq(IERC20(vault.asset()).balanceOf(ALICE), maxWithdrawable);
+    // Assert user has remainder shares after maxWithdrawable amount
+    assertEq(aliceSharesAfter, aliceShares - maxRedeemable);
   }
 
   function test_redeemwMaxWithoutRepay(uint96 amount, uint96 borrowAmount) public {
@@ -247,13 +253,18 @@ contract VaultUnitTests is MockingSetup, MockRoutines {
     do_depositAndBorrow(amount, borrowAmount, vault, ALICE);
 
     uint256 aliceShares = vault.balanceOf(ALICE);
+    uint256 maxWithdrawable = vault.maxWithdraw(ALICE);
     uint256 maxRedeemable = vault.maxRedeem(ALICE);
 
     vm.prank(ALICE);
     vault.redeem(type(uint256).max, ALICE, ALICE);
 
+    uint256 aliceSharesAfter = vault.balanceOf(ALICE);
+
+    // Assert user received exactly the maxWithdrawable amount
+    assertEq(IERC20(vault.asset()).balanceOf(ALICE), maxWithdrawable);
     // Assert user has remainder shares after maxRedeemable amount
-    assertEq(vault.balanceOf(ALICE), aliceShares - maxRedeemable);
+    assertEq(aliceSharesAfter, aliceShares - maxRedeemable);
   }
 
   function test_tryTransferWithoutRepay(uint96 amount, uint96 borrowAmount) public {


### PR DESCRIPTION
This pr addresses issues caused on the router because of conversion error in _paybackChecks.

Same logic was also applied to _withdrawChecks.

A test to analyze the reasoning behind the changes was included. `PrecisionMath.t.sol`. Fuzzing was used to verify.