### PR TITLE
Router replace amout after soft max withdrawal

### DIFF
--- a/packages/protocol/src/abstracts/BaseRouter.sol
+++ b/packages/protocol/src/abstracts/BaseRouter.sol
@@ -256,7 +256,7 @@ abstract contract BaseRouter is ReentrancyGuard, SystemAccessControl, IRouter {
           // If Withdraw is last action just withdraw
           vault.withdraw(amount, receiver, owner);
         } else {
-          _handleWithdrawWithFurtherActions(args[i], actions[i + 1], args[i + 1]);
+          args[i + 1] = _handleWithdrawWithFurtherActions(args[i], actions[i + 1], args[i + 1]);
         }
       } else if (action == Action.Borrow) {
         // BORROW
@@ -598,6 +598,7 @@ abstract contract BaseRouter is ReentrancyGuard, SystemAccessControl, IRouter {
     bytes memory nextArgs
   )
     private
+    returns (bytes memory updatedArgs)
   {
     (IVault vault, uint256 amount, address receiver, address owner) =
       abi.decode(arg, (IVault, uint256, address, address));
@@ -619,7 +620,7 @@ abstract contract BaseRouter is ReentrancyGuard, SystemAccessControl, IRouter {
       if (amount > updateAmount) {
         // If the withdraw `amount` encoded was > than the `owner`'s "maxWithdraw", the
         // difference in "(afterBal - prevBal)" must be less than amount.
-        (nextArgs,) = _replaceAmountArgInAction(nextAction, nextArgs, updateAmount);
+        (updatedArgs,) = _replaceAmountArgInAction(nextAction, nextArgs, updateAmount);
         // Since nextArgs is in memory and memory persist within internal calls the expected value
         // is updated.
       }

--- a/packages/protocol/src/abstracts/BaseRouter.sol
+++ b/packages/protocol/src/abstracts/BaseRouter.sol
@@ -603,6 +603,8 @@ abstract contract BaseRouter is ReentrancyGuard, SystemAccessControl, IRouter {
     (IVault vault, uint256 amount, address receiver, address owner) =
       abi.decode(arg, (IVault, uint256, address, address));
 
+    // Default to return same args
+    updatedArgs = nextArgs;
     if (
       (
         nextAction == Action.Deposit || nextAction == Action.Swap || nextAction == Action.XTransfer
@@ -621,12 +623,9 @@ abstract contract BaseRouter is ReentrancyGuard, SystemAccessControl, IRouter {
         // If the withdraw `amount` encoded was > than the `owner`'s "maxWithdraw", the
         // difference in "(afterBal - prevBal)" must be less than amount.
         (updatedArgs,) = _replaceAmountArgInAction(nextAction, nextArgs, updateAmount);
-        // Since nextArgs is in memory and memory persist within internal calls the expected value
-        // is updated.
       }
-    } else {
-      vault.withdraw(amount, receiver, owner);
     }
+    vault.withdraw(amount, receiver, owner);
   }
 
   /**

--- a/packages/protocol/src/routers/SimpleRouter.sol
+++ b/packages/protocol/src/routers/SimpleRouter.sol
@@ -43,6 +43,20 @@ contract SimpleRouter is BaseRouter {
   }
 
   /// @inheritdoc BaseRouter
+  function _replaceAmountInCrossAction(
+    Action,
+    bytes memory,
+    uint256
+  )
+    internal
+    pure
+    override
+    returns (bytes memory, uint256)
+  {
+    revert SimpleRouter__noCrossTransfersImplemented();
+  }
+
+  /// @inheritdoc BaseRouter
   function _getBeneficiaryFromCalldata(
     Action[] memory actions,
     bytes[] memory args


### PR DESCRIPTION
This pull request addresses the router issue of replacing arguments when the encoded amounnt-arg in actions after a Withraw happens differs from the "real" amount received. 