### PR TITLE
Disable wstETH bridging

### DIFF
--- a/packages/frontend/helpers/currencies.ts
+++ b/packages/frontend/helpers/currencies.ts
@@ -1,4 +1,4 @@
-import { Currency, UNBRIDGEABLE_TOKENS_SYMBOLS } from '@x-fuji/sdk';
+import { Currency, BRIDGEABLE_CURRENCY_SYMBOLS } from '@x-fuji/sdk';
 
 export const isNativeOrWrapped = (
   currency: Currency,
@@ -42,6 +42,6 @@ export const wrappedSymbol = (currency: Currency): string => {
 };
 
 // Temp helper functions
-export const isBridgeable = ({ symbol }: Currency): boolean => {
-  return !UNBRIDGEABLE_TOKENS_SYMBOLS.includes(symbol);
+export const isBridgeable = (currency: Currency): boolean => {
+  return BRIDGEABLE_CURRENCY_SYMBOLS.includes(currency.symbol);
 };

--- a/packages/frontend/helpers/currencies.ts
+++ b/packages/frontend/helpers/currencies.ts
@@ -43,5 +43,5 @@ export const wrappedSymbol = (currency: Currency): string => {
 
 // Temp helper functions
 export const isBridgeable = ({ symbol }: Currency): boolean => {
-  return symbol !== 'MaticX';
+  return symbol !== 'MaticX' && symbol !== 'wstETH';
 };

--- a/packages/frontend/helpers/currencies.ts
+++ b/packages/frontend/helpers/currencies.ts
@@ -1,4 +1,4 @@
-import { Currency } from '@x-fuji/sdk';
+import { Currency, UNBRIDGEABLE_TOKENS_SYMBOLS } from '@x-fuji/sdk';
 
 export const isNativeOrWrapped = (
   currency: Currency,
@@ -43,5 +43,5 @@ export const wrappedSymbol = (currency: Currency): string => {
 
 // Temp helper functions
 export const isBridgeable = ({ symbol }: Currency): boolean => {
-  return symbol !== 'MaticX' && symbol !== 'wstETH';
+  return !UNBRIDGEABLE_TOKENS_SYMBOLS.includes(symbol);
 };

--- a/packages/sdk/src/constants/currencies.ts
+++ b/packages/sdk/src/constants/currencies.ts
@@ -1,0 +1,7 @@
+export const BRIDGEABLE_CURRENCY_SYMBOLS: string[] = [
+  'ETH',
+  'USDC',
+  'USDT',
+  'DAI',
+  'WETH',
+];

--- a/packages/sdk/src/constants/index.ts
+++ b/packages/sdk/src/constants/index.ts
@@ -2,6 +2,7 @@ export * from './addresses';
 export * from './chain-properties';
 export * from './chains';
 export * from './common';
+export * from './currencies';
 export * from './errors';
 export * from './natives';
 export * from './rpcs';

--- a/packages/sdk/src/constants/tokens.ts
+++ b/packages/sdk/src/constants/tokens.ts
@@ -386,8 +386,3 @@ export const WNATIVE: TokenMap = {
     'Wrapped xDai'
   ),
 };
-
-export const UNBRIDGEABLE_TOKENS_SYMBOLS: string[] = [
-  MATICX.symbol,
-  WSTETH[ChainId.ETHEREUM].symbol, // One is enough
-];

--- a/packages/sdk/src/constants/tokens.ts
+++ b/packages/sdk/src/constants/tokens.ts
@@ -386,3 +386,8 @@ export const WNATIVE: TokenMap = {
     'Wrapped xDai'
   ),
 };
+
+export const UNBRIDGEABLE_TOKENS_SYMBOLS: string[] = [
+  MATICX.symbol,
+  WSTETH[ChainId.ETHEREUM].symbol, // One is enough
+];


### PR DESCRIPTION
close #696 

Added `wstETH` to a no-bridging list. If, in a crosschain operation, its required `wstETH` to be bridged, we're no longer allowing that.