### PR TITLE
Frontend cache for llamas

### DIFF
--- a/packages/frontend/helpers/cache.ts
+++ b/packages/frontend/helpers/cache.ts
@@ -66,13 +66,16 @@ export async function getLlamaCache(): Promise<GetLLamaFinancialsResponse> {
   });
 }
 
-export async function getCacheLastUpdatedDate(): Promise<Date> {
-  return new Promise(async (resolve, reject) => {
+export async function getCacheLastUpdatedDate(): Promise<Date | undefined> {
+  return new Promise(async (resolve) => {
     const db = await init();
     const transaction = db.transaction(['metaData'], 'readonly');
     const request = transaction.objectStore('metaData').get('lastUpdated');
 
-    request.onsuccess = () => resolve(request.result.date);
-    request.onerror = () => reject(request.error);
+    transaction.oncomplete = () => {
+      if (request.result) resolve(request.result.date);
+      resolve(undefined);
+    };
+    transaction.onerror = () => resolve(undefined);
   });
 }

--- a/packages/frontend/helpers/cache.ts
+++ b/packages/frontend/helpers/cache.ts
@@ -1,5 +1,7 @@
 import { GetLLamaFinancialsResponse } from '@x-fuji/sdk';
 
+export const CACHE_LIMIT = 1000 * 60 * 15; // Fifteen minutes
+
 let dbPromise: Promise<IDBDatabase> | null = null;
 
 function init(): Promise<IDBDatabase> {
@@ -8,7 +10,7 @@ function init(): Promise<IDBDatabase> {
   }
 
   dbPromise = new Promise((resolve, reject) => {
-    const request = indexedDB.open('myDatabase', 1);
+    const request = indexedDB.open('llama_cache', 1);
 
     request.onupgradeneeded = () => {
       const db = request.result;
@@ -28,8 +30,6 @@ function init(): Promise<IDBDatabase> {
 
   return dbPromise;
 }
-
-const HALF_AN_HOUR = 1800000; // 30 minutes in milliseconds
 
 export async function setLlamaCache(
   data: GetLLamaFinancialsResponse
@@ -66,8 +66,9 @@ export async function getLlamaCache(): Promise<GetLLamaFinancialsResponse> {
   });
 }
 
-export async function getLastUpdatedDate(): Promise<Date> {
-  return new Promise((resolve, reject) => {
+export async function getCacheLastUpdatedDate(): Promise<Date> {
+  return new Promise(async (resolve, reject) => {
+    const db = await init();
     const transaction = db.transaction(['metaData'], 'readonly');
     const request = transaction.objectStore('metaData').get('lastUpdated');
 

--- a/packages/frontend/helpers/cache.ts
+++ b/packages/frontend/helpers/cache.ts
@@ -1,0 +1,77 @@
+import { GetLLamaFinancialsResponse } from '@x-fuji/sdk';
+
+let dbPromise: Promise<IDBDatabase> | null = null;
+
+function init(): Promise<IDBDatabase> {
+  if (dbPromise) {
+    return dbPromise;
+  }
+
+  dbPromise = new Promise((resolve, reject) => {
+    const request = indexedDB.open('myDatabase', 1);
+
+    request.onupgradeneeded = () => {
+      const db = request.result;
+      db.createObjectStore('pools', { autoIncrement: true });
+      db.createObjectStore('lendBorrows', { autoIncrement: true });
+      db.createObjectStore('metaData', { keyPath: 'name' });
+    };
+
+    request.onsuccess = () => {
+      resolve(request.result);
+    };
+
+    request.onerror = () => {
+      reject(request.error);
+    };
+  });
+
+  return dbPromise;
+}
+
+const HALF_AN_HOUR = 1800000; // 30 minutes in milliseconds
+
+export async function setLlamaCache(
+  data: GetLLamaFinancialsResponse
+): Promise<void> {
+  const db = await init();
+  const transaction = db.transaction(
+    ['pools', 'lendBorrows', 'metaData'],
+    'readwrite'
+  );
+
+  transaction.objectStore('pools').put(data.pools);
+  transaction.objectStore('lendBorrows').put(data.lendBorrows);
+  transaction
+    .objectStore('metaData')
+    .put({ name: 'lastUpdated', date: new Date() });
+}
+
+export async function getLlamaCache(): Promise<GetLLamaFinancialsResponse> {
+  return new Promise(async (resolve, reject) => {
+    const db = await init();
+    const transaction = db.transaction(['pools', 'lendBorrows'], 'readonly');
+
+    const poolsRequest = transaction.objectStore('pools').get(1);
+    const lendBorrowsRequest = transaction.objectStore('lendBorrows').get(1);
+
+    transaction.oncomplete = () => {
+      resolve({
+        pools: poolsRequest.result,
+        lendBorrows: lendBorrowsRequest.result,
+      });
+    };
+
+    transaction.onerror = () => reject(transaction.error);
+  });
+}
+
+export async function getLastUpdatedDate(): Promise<Date> {
+  return new Promise((resolve, reject) => {
+    const transaction = db.transaction(['metaData'], 'readonly');
+    const request = transaction.objectStore('metaData').get('lastUpdated');
+
+    request.onsuccess = () => resolve(request.result.date);
+    request.onerror = () => reject(request.error);
+  });
+}

--- a/packages/frontend/helpers/markets.tsx
+++ b/packages/frontend/helpers/markets.tsx
@@ -270,7 +270,8 @@ export const fetchMarkets = async (
     api.getState().changeRows(type, setBest(rowsFin, type));
     api.getState().changeVaultsWithFinancials(type, vaultsWithFinancials);
   }
-  const llamaResult = await sdk.getLlamaFinancials(allVaults);
+
+  const llamaResult = await sdk.getLlamasForVaults(allVaults);
   if (!llamaResult.success) {
     notify({
       type: 'error',

--- a/packages/frontend/helpers/markets.tsx
+++ b/packages/frontend/helpers/markets.tsx
@@ -19,7 +19,11 @@ import { AssetType } from './assets';
 import { chainName, chains } from './chains';
 import { shouldShowStoreNotification } from './navigation';
 import { notify, showOnchainErrorNotification } from './notifications';
-import { getVaultFinancials, vaultsFromFinancialsOrError } from './vaults';
+import {
+  getLlamasWithFinancials,
+  getVaultFinancials,
+  vaultsFromFinancialsOrError,
+} from './vaults';
 
 const defaultRow: MarketRow = {
   collateral: '',
@@ -271,17 +275,18 @@ export const fetchMarkets = async (
     api.getState().changeVaultsWithFinancials(type, vaultsWithFinancials);
   }
 
-  const llamaResult = await sdk.getLlamasForVaults(allVaults);
-  if (!llamaResult.success) {
+  const llamasResult = await getLlamasWithFinancials();
+  if (!llamasResult.success) {
     notify({
       type: 'error',
-      message: llamaResult.error.message,
+      message: llamasResult.error.message,
     });
     const rows = rowsFin.map((r) => setLlamas(r, MarketRowStatus.Error));
     api.getState().changeRows(type, setBest(rows, type));
     return;
   }
-  const vaultsWithLlamas = llamaResult.data;
+
+  const vaultsWithLlamas = sdk.getLlamasForVaults(allVaults, llamasResult.data);
   const rowsLlama = vaultsWithFinancials.map((obj, i) => {
     const llama =
       obj instanceof FujiError

--- a/packages/frontend/helpers/vaults.ts
+++ b/packages/frontend/helpers/vaults.ts
@@ -2,6 +2,9 @@ import {
   AbstractVault,
   Address,
   FujiError,
+  FujiResultPromise,
+  FujiResultSuccess,
+  GetLLamaFinancialsResponse,
   VaultType,
   VaultWithFinancials,
 } from '@x-fuji/sdk';
@@ -10,6 +13,12 @@ import { DUST_AMOUNT_IN_WEI } from '../constants';
 import { sdk } from '../services/sdk';
 import { useBorrow } from '../store/borrow.store';
 import { useLend } from '../store/lend.store';
+import {
+  CACHE_LIMIT,
+  getCacheLastUpdatedDate,
+  getLlamaCache,
+  setLlamaCache,
+} from './cache';
 import { chains } from './chains';
 import { notify } from './notifications';
 
@@ -18,7 +27,7 @@ export type FinancialsOrError = VaultWithFinancials | FujiError;
 export const getVaultsWithFinancials = async (
   availableVaults: VaultWithFinancials[]
 ) => {
-  const llamaResult = await sdk.getLlamasForVaults(availableVaults);
+  const llamaResult = await getLlamasWithFinancials();
 
   if (!llamaResult.success) {
     notify({
@@ -29,7 +38,7 @@ export const getVaultsWithFinancials = async (
 
   availableVaults =
     llamaResult.success && llamaResult.data
-      ? llamaResult.data
+      ? sdk.getLlamasForVaults(availableVaults, llamaResult.data)
       : availableVaults;
 
   return availableVaults;
@@ -89,3 +98,27 @@ export const allAvailableVaults = (): VaultWithFinancials[] => [
   ...useBorrow.getState().availableVaults,
   ...useLend.getState().availableVaults,
 ];
+
+export const getLlamasWithFinancials =
+  async (): FujiResultPromise<GetLLamaFinancialsResponse> => {
+    const lastUpdated = await getCacheLastUpdatedDate();
+    const cache = await getLlamaCache();
+    const now = new Date();
+
+    const shouldFetch =
+      !lastUpdated ||
+      now.getTime() - lastUpdated.getTime() > CACHE_LIMIT ||
+      !cache.lendBorrows ||
+      !cache.pools;
+
+    if (shouldFetch) {
+      const financialsResult = await sdk.getLLamaFinancials();
+      if (!financialsResult.success) {
+        return financialsResult;
+      }
+      const llamas = financialsResult.data;
+      setLlamaCache(llamas);
+      return new FujiResultSuccess(llamas);
+    }
+    return new FujiResultSuccess(cache);
+  };

--- a/packages/frontend/helpers/vaults.ts
+++ b/packages/frontend/helpers/vaults.ts
@@ -18,7 +18,7 @@ export type FinancialsOrError = VaultWithFinancials | FujiError;
 export const getVaultsWithFinancials = async (
   availableVaults: VaultWithFinancials[]
 ) => {
-  const llamaResult = await sdk.getLlamaFinancials(availableVaults);
+  const llamaResult = await sdk.getLlamasForVaults(availableVaults);
 
   if (!llamaResult.success) {
     notify({

--- a/packages/sdk/src/Sdk.ts
+++ b/packages/sdk/src/Sdk.ts
@@ -414,19 +414,17 @@ export class Sdk {
    * Returns all vaults with the financial data loaded from DefiLlama API.
    *
    * @param vaults - returned value from "getAllVaultsWithFinancials()"
+   * @param llamas - llama information returned from "getLLamaFinancials()"
    */
-  async getLlamasForVaults(
-    vaults: VaultWithFinancials[]
-  ): FujiResultPromise<VaultWithFinancials[]> {
-    const result = await this.getLLamaFinancials();
-    if (!result.success) {
-      return new FujiResultError(result.error.message);
-    }
-    const { lendBorrows, pools } = result.data;
+  getLlamasForVaults(
+    vaults: VaultWithFinancials[],
+    llamas: GetLLamaFinancialsResponse
+  ): VaultWithFinancials[] {
+    const { lendBorrows, pools } = llamas;
     const data = vaults.map((vault) =>
       this._getFinancialsFor(vault, pools, lendBorrows)
     );
-    return new FujiResultSuccess(data);
+    return data;
   }
 
   /**

--- a/packages/sdk/src/Sdk.ts
+++ b/packages/sdk/src/Sdk.ts
@@ -11,7 +11,6 @@ import {
   CONNEXT_URL,
   FujiErrorCode,
   NATIVE,
-  URLS,
 } from './constants';
 import { Address, Currency, Token } from './entities';
 import { AbstractVault } from './entities/abstract/AbstractVault';
@@ -32,6 +31,7 @@ import {
 import {
   encodeActionArgs,
   findPermitAction,
+  llamaFinancials,
   waitForTransaction,
 } from './functions';
 import {
@@ -52,8 +52,7 @@ import {
 } from './types';
 import { ConnextRouter__factory } from './types/contracts';
 import {
-  GetLlamaAssetPoolsResponse,
-  GetLlamaLendBorrowPoolsResponse,
+  GetLLamaFinancialsResponse,
   LlamaAssetPool,
   LlamaLendBorrowPool,
 } from './types/LlamaResponses';
@@ -398,48 +397,36 @@ export class Sdk {
   }
 
   /**
-   * Returns all vaults with the whole financial data
-   * loaded from DefiLlama API.
+   * Returns financial data from DefiLlama API.
    *
    * @remarks
    * This data is fetched from DefiLlama API and it can take
    * longer than expected to get loaded. Their API is considered being in a
    * "experimental" mode and might be unstable.
+   */
+
+  async getLLamaFinancials(): FujiResultPromise<GetLLamaFinancialsResponse> {
+    const { defillamaproxy } = this._configParams;
+    return await llamaFinancials(defillamaproxy);
+  }
+
+  /**
+   * Returns all vaults with the financial data loaded from DefiLlama API.
    *
    * @param vaults - returned value from "getAllVaultsWithFinancials()"
    */
-  async getLlamaFinancials(
+  async getLlamasForVaults(
     vaults: VaultWithFinancials[]
   ): FujiResultPromise<VaultWithFinancials[]> {
-    // fetch from DefiLlama
-    const { defillamaproxy } = this._configParams;
-    const uri = {
-      lendBorrow: defillamaproxy
-        ? defillamaproxy + 'lendBorrow'
-        : URLS.DEFILLAMA_LEND_BORROW,
-      pools: defillamaproxy ? defillamaproxy + 'pools' : URLS.DEFILLAMA_POOLS,
-    };
-    try {
-      const [lendBorrows, pools] = await Promise.all([
-        axios
-          .get<GetLlamaLendBorrowPoolsResponse>(uri.lendBorrow)
-          .then(({ data }) => data),
-        axios
-          .get<GetLlamaAssetPoolsResponse>(uri.pools)
-          .then(({ data }) => data.data),
-      ]);
-
-      const data = vaults.map((vault) =>
-        this._getFinancialsFor(vault, pools, lendBorrows)
-      );
-      return new FujiResultSuccess(data);
-    } catch (e) {
-      const message = axios.isAxiosError(e)
-        ? `DefiLlama API call failed with a message: ${e.message}`
-        : 'DefiLlama API call failed with an unexpected error!';
-      console.error(message);
-      return new FujiResultError(message, FujiErrorCode.LLAMA);
+    const result = await this.getLLamaFinancials();
+    if (!result.success) {
+      return new FujiResultError(result.error.message);
     }
+    const { lendBorrows, pools } = result.data;
+    const data = vaults.map((vault) =>
+      this._getFinancialsFor(vault, pools, lendBorrows)
+    );
+    return new FujiResultSuccess(data);
   }
 
   /**

--- a/packages/sdk/src/functions/index.ts
+++ b/packages/sdk/src/functions/index.ts
@@ -4,4 +4,5 @@ export { findPermitAction } from './findPermitAction';
 export { getPermitDigest } from './getPermitDigest';
 export { getPreviewActions } from './getPreviewActions';
 export { getPreviewRoutingDetails } from './getPreviewRoutingDetails';
+export { llamaFinancials } from './llamaFinancials';
 export { waitForTransaction } from './waitForTransaction';

--- a/packages/sdk/src/functions/llamaFinancials.ts
+++ b/packages/sdk/src/functions/llamaFinancials.ts
@@ -1,0 +1,39 @@
+import axios from 'axios';
+
+import { FujiErrorCode, URLS } from '../constants';
+import { FujiResultError, FujiResultSuccess } from '../entities';
+import { FujiResultPromise } from '../types';
+import {
+  GetLlamaAssetPoolsResponse,
+  GetLLamaFinancialsResponse,
+  GetLlamaLendBorrowPoolsResponse,
+} from '../types/LlamaResponses';
+
+export async function llamaFinancials(
+  defillamaproxy: string | undefined
+): FujiResultPromise<GetLLamaFinancialsResponse> {
+  // fetch from DefiLlama
+  const uri = {
+    lendBorrow: defillamaproxy
+      ? defillamaproxy + 'lendBorrow'
+      : URLS.DEFILLAMA_LEND_BORROW,
+    pools: defillamaproxy ? defillamaproxy + 'pools' : URLS.DEFILLAMA_POOLS,
+  };
+  try {
+    const [lendBorrows, pools] = await Promise.all([
+      axios
+        .get<GetLlamaLendBorrowPoolsResponse>(uri.lendBorrow)
+        .then(({ data }) => data),
+      axios
+        .get<GetLlamaAssetPoolsResponse>(uri.pools)
+        .then(({ data }) => data.data),
+    ]);
+    return new FujiResultSuccess({ lendBorrows, pools });
+  } catch (e) {
+    const message = axios.isAxiosError(e)
+      ? `DefiLlama API call failed with a message: ${e.message}`
+      : 'DefiLlama API call failed with an unexpected error!';
+    console.error(message);
+    return new FujiResultError(message, FujiErrorCode.LLAMA);
+  }
+}

--- a/packages/sdk/src/types/LlamaResponses.ts
+++ b/packages/sdk/src/types/LlamaResponses.ts
@@ -41,3 +41,8 @@ export type GetLlamaPoolStatsResponse = {
 };
 
 export type GetLlamaLendBorrowPoolsResponse = LlamaLendBorrowPool[];
+
+export type GetLLamaFinancialsResponse = {
+  lendBorrows: LlamaLendBorrowPool[];
+  pools: LlamaAssetPool[];
+};

--- a/packages/sdk/src/types/index.ts
+++ b/packages/sdk/src/types/index.ts
@@ -7,6 +7,7 @@ export * from './ChainVaultList';
 export * from './ConnextTxDetails';
 export * from './FujiResult';
 export * from './LendingProvider';
+export * from './LlamaResponses';
 export * from './MetaRoutingResult';
 export * from './NativeMap';
 export * from './PreviewParams';


### PR DESCRIPTION
close #717 

In order to reduce the number of calls we make to an API (Defillama or ours) and before deploying our own express + redis API, I added a local cache with `indexedDB`.

Now we will only call an API to get the data once in fifteen minutes -rest of the time we'll load data locally. 

In order to do this, I had to decouple to functions on the sdk that were calling an API and parsing through its response.