### PR TITLE
Rebalancer manager error with zero debt rebalance

### DIFF
--- a/packages/protocol/deploy-configs/ethereum.json
+++ b/packages/protocol/deploy-configs/ethereum.json
@@ -198,6 +198,15 @@
       "rating": 85
     },
     {
+      "collateral": "WETH",
+      "debt": "DAI",
+      "liqRatio": 820000000000000000,
+      "maxLtv": 800000000000000000,
+      "name": "BorrowingVault-WETHDAI-1",
+      "providers": ["Spark","Morpho_Compound", "Morpho_Aave_V2"],
+      "rating": 85
+    },
+    {
       "collateral": "WSTETH",
       "debt": "USDC",
       "liqRatio": 850000000000000000,

--- a/packages/protocol/deploy-configs/gnosis.json
+++ b/packages/protocol/deploy-configs/gnosis.json
@@ -73,6 +73,24 @@
       "name": "BorrowingVault-WSTETGNO-1",
       "providers": ["Agave_Gnosis"],
       "rating": 75
+    },
+    {
+      "collateral": "WETH",
+      "debt": "DAI",
+      "liqRatio": 800000000000000000,
+      "maxLtv": 750000000000000000,
+      "name": "BorrowingVault-WETHDAI-1",
+      "providers": ["Agave_Gnosis"],
+      "rating": 80
+    },
+    {
+      "collateral": "WBTC",
+      "debt": "DAI",
+      "liqRatio": 750000000000000000,
+      "maxLtv": 700000000000000000,
+      "name": "BorrowingVault-WBTCDAI-1",
+      "providers": ["Agave_Gnosis"],
+      "rating": 80
     }
   ],
   "yield-vaults": [

--- a/packages/protocol/deploy-configs/polygon.json
+++ b/packages/protocol/deploy-configs/polygon.json
@@ -95,10 +95,10 @@
     {
       "collateral": "MATICX",
       "debt": "USDC",
-      "liqRatio": 670000000000000000,
-      "maxLtv": 560000000000000000,
+      "liqRatio": 600000000000000000,
+      "maxLtv": 550000000000000000,
       "name": "BorrowingVault-MATICXUSDC-1",
-      "providers": ["Aave_V3_Polygon"],
+      "providers": ["Aave_V3_Polygon","Compound_V3_Polygon"],
       "rating": 90
     },
     {

--- a/packages/protocol/src/RebalancerManager.sol
+++ b/packages/protocol/src/RebalancerManager.sol
@@ -279,6 +279,14 @@ contract RebalancerManager is IRebalancerManager, SystemAccessControl {
   }
 
   /**
+   * @dev Reset the `_entryPoint` state variable.
+   */
+  function _resetEntryPoint() private {
+    // Reset the `_entryPoint`.
+    _entryPoint = "";
+  }
+
+  /**
    * @notice Callback function that completes execution logic of a rebalance
    * operation with a flashloan.
    *
@@ -327,8 +335,20 @@ contract RebalancerManager is IRebalancerManager, SystemAccessControl {
 
     debtAsset.safeTransfer(address(flasher), debt + flashloanFee);
 
-    // Re-initialize the `_entryPoint`.
-    _entryPoint = "";
+    _resetEntryPoint();
     success = true;
+  }
+
+  /**
+   * @dev Forces to reset the `_entryPoint` state variable.
+   * This is needed in emergency case that  `_resetEntryPoint()` is not reached due to
+   * external failure in execution of `completeRebalance()`.
+   * Otherwise, RebalancerManager will remain inoperable.
+   *
+   * Requirements:
+   * - Must be called from the timelock.
+   */
+  function hardResetEntryPoint() external onlyTimelock {
+    _resetEntryPoint();
   }
 }

--- a/packages/protocol/src/RebalancerManager.sol
+++ b/packages/protocol/src/RebalancerManager.sol
@@ -306,6 +306,11 @@ contract RebalancerManager is IRebalancerManager, SystemAccessControl {
     external
     returns (bool success)
   {
+    // Check caller is a valid flasher
+    if (!chief.allowedFlasher(msg.sender)) {
+      revert RebalancerManager__rebalanceVault_notValidFlasher();
+    }
+    // Check flashloan originator is reentering properly
     _checkReentry(vault, assets, debt, from, to, flasher, setToAsActiveProvider);
 
     IERC20 debtAsset = IERC20(vault.debtAsset());


### PR DESCRIPTION
I noticed that in rebalancing borrowing vaults that only had assets (no debt) the flashloan is not needed. There was a case in where flashloaning zero debt resulted in a "successful" but useless tx that got the Rebalancer locked because it wrote to the `entryPoint` state but never completed the execution and therefore the Rebalancer is locked from being used again.

The fixes of this PR avoid using flashloan when rebalancing a borrowing vault that only has assets ( or zero debt), and a new function restricted to the timelock is added to unblock the `entryPoint` variable in case is necessary. The reason why this is restricted to the timelock is to avoid, reentrancies by malicious `allowedExecutor` users who could figure out ways to by-pass checks of the `entryPoint`.
