### PR TITLE
Remove performance tracking

### DIFF
--- a/packages/frontend/helpers/errors.ts
+++ b/packages/frontend/helpers/errors.ts
@@ -1,5 +1,4 @@
 import * as Sentry from '@sentry/react';
-import { BrowserTracing } from '@sentry/tracing';
 
 import { HELPER_URL, NOTIFICATION_MESSAGES, SENTRY_DSN } from '../constants';
 import {

--- a/packages/frontend/helpers/errors.ts
+++ b/packages/frontend/helpers/errors.ts
@@ -20,8 +20,6 @@ export const initErrorReporting = () => {
   }
   Sentry.init({
     dsn: SENTRY_DSN,
-    integrations: [new BrowserTracing()],
-    tracesSampleRate: 1.0,
   });
 };
 


### PR DESCRIPTION
We had performance tracking enabled through Sentry. Recently we got a message saying we "depleted this month's performance unit capacit". Truth is, we aren't even using it. We have a decent event history if we want to use it, but we can safely remove the feature for the time being.